### PR TITLE
Two small fixes to DSRRouteTable

### DIFF
--- a/elements/grid/dsrroutetable.cc
+++ b/elements/grid/dsrroutetable.cc
@@ -955,14 +955,6 @@ DSRRouteTable::add_dsr_header(Packet *p_in, const Vector<IPAddress> &source_rout
 
   DEBUG_CHATTER(" * add_dsr_header: new packet size is %d, old was %d \n", p->length(), old_len);
 
-  // there's not really much mention of TTL in the IETF draft (other
-  // than in the case of RREQs), I suppose it's sort of implicitly the
-  // length of the source route.  so right now we're not checking OR
-  // decrementing the TTL when forwarding (again, except in the case
-  // of RREQs).
-  //
-  ip->ip_ttl = 255;
-
   ip->ip_len = htons(p->length());
   ip->ip_dst.s_addr = (unsigned)p->dst_ip_anno(); // XXX not sure I understand why we need to reset this
   ip->ip_sum = 0;


### PR DESCRIPTION
- Fix an incomplete click_chatter() call
- Make add_dsr_header() _not_ reset the TTL of the to-be-sent IP packet to 255 (instead use value of the incoming IP packet, usually the operating system default)

Love your work. Thanks for Click!
