### PR TITLE
UDPTimeCheck -> StoreUDPTimeSeqRecord

### DIFF
--- a/elements/tcpudp/storeudptimeseqrecord.hh
+++ b/elements/tcpudp/storeudptimeseqrecord.hh
@@ -13,24 +13,32 @@ Programmer: Roman Chertov
  * notice is a summary of the Click LICENSE file; the license in that file is
  * legally binding.
 */
-#ifndef CLICK_UDPTIMECHECK_HH
-#define CLICK_UDPTIMECHECK_HH
+#ifndef CLICK_STOREUDPTIMESEQRECORD_HH
+#define CLICK_STOREUDPTIMESEQRECORD_HH
 #include <click/element.hh>
 
 
 
 /*
-UDPTimeCheck element can be handy when computing end-to-end UDP packet
+=c
+
+StoreUDPTimeSeqRecord([I<keywords> OFFSET, DELTA])
+
+=s
+
+StoreUDPTimeSeqRecord element can be handy when computing end-to-end UDP packet
 delays.  The element embeds a timestamp and a sequence number into a packet and 
 adjusts the checksum of the UDP packet.  Once the initial timestamp has been 
 placed into the payload of the UDP packet, a time difference can be computed 
-once a packet passes through another UDPTimeCheck element.  The data can be 
+once a packet passes through another StoreUDPTimeSeqRecord element.  The data can be
 accessed by examining the packet payload (e.g., do a tcpdump and then do post 
-processing of the data).  The element uses partial checksums to speed up the 
-processing.
+processing of the data).  The element uses partial checksums to speed up the
+processing.  The element works with IPv4 and IPv6 packets.  In case of IPv6,
+it assumes that the next header field is UDP.  If this is not the case, the
+element will discard the packet.
 
 Packet payload found after the UDP header.  Note, the UDP payload must be at least 
-22 bytes long.
+22 bytes long.  The values will be stored in network byte order.
 
 uint32_t seq_num
 uint32_t initial_second 
@@ -40,18 +48,19 @@ uint32_t difference_nano_second
 
 Keyword arguments are:
 
-=over 3
+=over 2
 
 =item OFFSET
 
-Number of bytes to offset from the beginning of the packet where the IP header can be found.
-If raw Ethernet packets are fed into this element, then OFFSET needs to be 14.
+Number of bytes to offset from the beginning of the packet where the IPv4/6 header can be found.
+If raw Ethernet packets are fed into this element, then OFFSET needs to be 14.  
 
-=item IN
+=item DELTA
 
-Determines if the time difference needs to be computed or if the initial timestamp needs to 
-be set.  If IN is false, then the initial timestamp is set.  If IN is true, then the 
-time difference is computed between the initial timestamp and now.
+Determines which time values are set. If DELTA is false (the default), then the initial_second
+and initial_nano_second values are set to the current time, and the difference values are set to 0.
+If DELTA is true, then the initial values are left as is, and the difference values are set to
+the difference between the current time and the packet's initial time.
 
 =back
 
@@ -59,17 +68,17 @@ time difference is computed between the initial timestamp and now.
     src :: RatedSource(\<00>, LENGTH 22, RATE 1, LIMIT 100)
         -> UDPIPEncap(10.0.1.1, 6667, 20.0.0.2, 6667)
         -> EtherEncap(0x0800, 00:04:23:D0:93:63, 00:17:cb:0d:f8:db)
-        -> UDPTimeCheck(OFFSET 34, IN false)
+        -> StoreUDPTimeSeqRecord(OFFSET 14, DELTA false)
         -> DelayShaper(100msec)
-        -> UDPTimeCheck(OFFSET 34, IN true)
+        -> StoreUDPTimeSeqRecord(OFFSET 14, DELTA true)
         -> ToDump("dump.dmp");
 */
-class UDPTimeCheck : public Element
+class StoreUDPTimeSeqRecord : public Element
 {
 public:
-    UDPTimeCheck();
+    StoreUDPTimeSeqRecord();
 
-    const char *class_name() const	{ return "UDPTimeCheck"; }
+    const char *class_name() const	{ return "StoreUDPTimeSeqRecord"; }
     const char *port_count() const	{ return PORTS_1_1; }
     const char *processing() const	{ return AGNOSTIC; }
 
@@ -89,9 +98,8 @@ public:
 
 private:
     unsigned long _count;
-    bool          _in;  // if true put in_timestamp else out_timestamp
-    bool          _csum; // do we fix the checksums or not
-    uint32_t      _offset; //how much to shift to get to the IPv4 header
+    bool          _delta;  // if true put in_timestamp else out_timestamp
+    uint32_t      _offset; //how much to shift to get to the IPv4/v6 header
 
     static String read_handler(Element *, void *);
     static int    reset_handler(const String &, Element *, void *, ErrorHandler *);

--- a/tools/click-align/click-align.cc
+++ b/tools/click-align/click-align.cc
@@ -282,7 +282,7 @@ static ElementClassT *class_factory(const String &name)
 	return new AlignClass(name, new GeneratorAligner(Alignment::make_universal()));
     if (name == "IPEncap" || name == "UDPIPEncap" || name == "ICMPPingEncap"
 	|| name == "RandomUDPIPEncap" || name == "RoundRobinUDPIPEncap"
-	|| name == "RoundRobinTCPIPEncap" || name == "UDPTimeCheck")
+	|| name == "RoundRobinTCPIPEncap" || name == "StoreUDPTimeSeqRecord")
 	return new AlignClass(name, new WantAligner(Alignment(4, 0)));
     if (name == "ARPResponder")
 	return new AlignClass(name, new WantAligner(Alignment(2, 0)));


### PR DESCRIPTION
Eddie,

I changed the name and changed the behavior a bit.  I dropped the CSUM argument completely.  I am not sure if it makes sense not to compute the updated checksum after the UDP data has been changed.  I also enabled IPv6 processing provided that the header after the IPv6 header is a UDP one.  It also handles variable sized IPv4 headers.  The OFFSET as you suggested now points to the start of the IPv4/6 header, and the element figures out by itself how to get to the UDP header.  In case it can't, it will drop the packet.  The checksum issue has been solved for cases when PData was not all zeros.  I have provided two test cases below to show that it works for IPv4 and IPv6 with a non-zero initial data in the PData structure.

src :: RatedSource(<010101010101010101010101010101010101010101010101>, LENGTH 22, RATE 1, LIMIT 100)
    -> UDPIPEncap(10.0.1.1, 6667, 20.0.0.2, 6667)
    -> EtherEncap(0x0800, 00:04:23:D0:93:63, 00:17:cb:0d:f8:db)
    -> t1 :: StoreUDPTimeSeqRecord(OFFSET 14, DELTA false)
    -> d :: DelayShaper(100msec)
    -> t2 :: StoreUDPTimeSeqRecord(OFFSET 14, DELTA true)
    -> ToDump("dump.dmp");

src :: RatedSource(<010101010101010101010101010101010101010101010101>, LENGTH 22, RATE 1, LIMIT 100)
    -> UDPIP6Encap(2000:10:1::2, 6667, 2000:20:1::2, 6667)
    -> EtherEncap(0x0800, 00:04:23:D0:93:63, 00:17:cb:0d:f8:db)
    -> t1 :: StoreUDPTimeSeqRecord(OFFSET 14, DELTA false)
    -> d :: DelayShaper(100msec)
    -> t2 :: StoreUDPTimeSeqRecord(OFFSET 14, DELTA true)
    -> ToDump("dump.dmp");
