### PR TITLE
Add (un)stripdsr

### DIFF
--- a/elements/grid/stripdsrheader.cc
+++ b/elements/grid/stripdsrheader.cc
@@ -1,0 +1,99 @@
+/*
+ * stripdsrheader.{cc,hh} -- element removes DSR header (saving it for later)
+ * Florian Sesser, Technical University of Munich, 2010
+ *
+ * Based on work by Eddie Kohler, Shweta Bhandare, Sagar Sanghani,
+ * Sheetalkumar Doshi, Timothy X Brown Daniel Aguayo
+ *
+ * Copyright (c) 2003 Massachusetts Institute of Technology
+ * Copyright (c) 2003 University of Colorado at Boulder
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
+#include <click/config.h>
+#include "stripdsrheader.hh"
+#include <click/packet_anno.hh>
+#include <clicknet/ip.h>
+#include "dsr.hh"
+CLICK_DECLS
+
+StripDSRHeader::StripDSRHeader()
+{
+}
+
+StripDSRHeader::~StripDSRHeader()
+{
+}
+
+Packet *
+StripDSRHeader::simple_action(Packet *p)
+{
+    const click_dsr_option *dsr_option = (const click_dsr_option *)
+					    (p->data() + sizeof(click_ip)
+					     + sizeof(click_dsr));
+
+    if (dsr_option->dsr_type != DSR_TYPE_SOURCE_ROUTE) {
+	// this is not a DSR DATA packet -- do "nothing"
+	// (but mark the packet to not unstrip it later)
+	SET_VLAN_ANNO(p, 1);
+	// click_chatter("StripDSR: Marked non-payload");
+	return p;
+    }
+
+    return swap_headers(p);
+}
+
+// from dsrroutetable.cc, was called strip_headers()
+// removes all DSR headers, leaving an ordinary IP packet
+// changes: saves DSR header to later be able to undo the stripping
+Packet *
+StripDSRHeader::swap_headers(Packet *p_in)
+{
+  WritablePacket *p = p_in->uniqueify();
+  click_ip *ip = reinterpret_cast<click_ip *>(p->data());
+  click_dsr *dsr = (click_dsr *)(p->data() + sizeof(click_ip));
+
+  assert(ip->ip_p == IP_PROTO_DSR);
+
+  // get the length of the DSR headers from the fixed header
+  unsigned dsr_len = sizeof(click_dsr) + ntohs(dsr->dsr_len);
+
+  // save the IP header
+  click_ip new_ip;
+  memcpy(&new_ip, ip, sizeof(click_ip));
+  new_ip.ip_p = dsr->dsr_next_header;
+
+  // save the to-be-overwritten DSR part to the orig. ip header (swap them)
+  memcpy(ip, dsr, dsr_len);
+  // save the offset to the VLAN_ANNO tag
+  SET_VLAN_ANNO(p, htons(dsr_len));
+
+  // remove the headers
+  p->pull(dsr_len);
+
+  memcpy(p->data(), &new_ip, sizeof(click_ip));
+  ip=reinterpret_cast<click_ip *>(p->data());
+  ip->ip_len=htons(p->length());
+  ip->ip_sum=0;
+  ip->ip_sum=click_in_cksum((unsigned char *)ip,sizeof(click_ip));
+
+  p->set_ip_header((click_ip*)p->data(),sizeof(click_ip));
+
+  // click_chatter("StripDSR: Removed %d bytes\n", dsr_len);
+
+  return p;
+}
+
+
+CLICK_ENDDECLS
+EXPORT_ELEMENT(StripDSRHeader)
+ELEMENT_MT_SAFE(StripDSRHeader)

--- a/elements/grid/stripdsrheader.hh
+++ b/elements/grid/stripdsrheader.hh
@@ -1,0 +1,50 @@
+#ifndef CLICK_STRIPDSRHEADER_HH
+#define CLICK_STRIPDSRHEADER_HH
+#include <click/element.hh>
+CLICK_DECLS
+
+/*
+ * =c
+ * StripDSRHeader()
+ * =s grid
+ * strips DSR header, saves offset to VLAN_ANNO
+ * =d
+ *
+ * Strips the DSR header from DSR packets, saving the offset to
+ * the VLAN_ANNO tag. Control packets are not stripped.
+ *
+ * This element helps if one wants to modify the payload inside a DSR data
+ * packet. The code to parse the DSR header is taken from Click's grid
+ * elements (DSRRouteTable etc).
+ *
+ * The IP header is set to the payload of the DSR packet.  After modifying the
+ * inner IP packet, UnstripDSRHeader can be used to restore the DSR header.
+ *
+ * Based on Click's StripIPHeader and DSRRouteTable elements.
+ *
+ * =a CheckIPHeader, MarkIPHeader, StripIPHeader, DSRRouteTable
+ *
+ * =e
+ * //DSR routing packets should go to input 1 of the DSR router
+ * DSR_classifier::Classifier(09/C8,-)
+ *    -> StripDSRHeader
+ *    -> [... modify payload, stamp in timestamp or so ...]
+ *    -> UnstripDSRHeader
+ *    -> [1]dsr_rt::DSRRouteTable(...);
+ */
+
+class StripDSRHeader : public Element { public:
+
+    StripDSRHeader();
+    ~StripDSRHeader();
+
+    const char *class_name() const		{ return "StripDSRHeader"; }
+    const char *port_count() const		{ return PORTS_1_1; }
+
+    Packet *simple_action(Packet *);
+
+    Packet *swap_headers(Packet *);
+};
+
+CLICK_ENDDECLS
+#endif

--- a/elements/grid/unstripdsrheader.cc
+++ b/elements/grid/unstripdsrheader.cc
@@ -1,0 +1,85 @@
+/*
+ * unstripdsrheader.{cc,hh} -- put IP header back based on annotation
+ *
+ * Based on work by Eddie Kohler, Shweta Bhandare, Sagar Sanghani,
+ * Sheetalkumar Doshi, Timothy X Brown Daniel Aguayo, Benjie Chen
+ *
+ * Copyright (c) 2003 Massachusetts Institute of Technology
+ * Copyright (c) 2003 University of Colorado at Boulder
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
+#include <click/config.h>
+#include "unstripdsrheader.hh"
+#include <click/packet_anno.hh>
+#include <clicknet/ip.h>
+#include "dsr.hh"
+CLICK_DECLS
+
+UnstripDSRHeader::UnstripDSRHeader()
+{
+}
+
+UnstripDSRHeader::~UnstripDSRHeader()
+{
+}
+
+Packet *
+UnstripDSRHeader::simple_action(Packet *p_in)
+{
+    if (VLAN_ANNO(p_in) == 0) {
+	// click_chatter("UnstripDSR: No VLAN_ANNO, no DSR unstripping");
+	return p_in;
+    }
+    if (VLAN_ANNO(p_in) == 1) {
+	// click_chatter("UnstripDSR: Packet had been marked non-payload");
+	SET_VLAN_ANNO(p_in, 0);
+	return p_in;
+    }
+
+    ptrdiff_t dsr_len = ntohs(VLAN_ANNO(p_in));
+
+    WritablePacket *p = p_in->uniqueify();
+    click_dsr *dsr_old = reinterpret_cast<click_dsr *>(p->data() - dsr_len);
+    click_dsr *dsr_new = reinterpret_cast<click_dsr *>(p->data() - dsr_len +
+							sizeof(click_ip));
+    click_ip *ip = (click_ip *)(p->data());
+
+    // save the IP header
+    click_ip new_ip;
+    memcpy(&new_ip, ip, sizeof(click_ip));
+    new_ip.ip_p = IP_PROTO_DSR;
+
+    // fetch the original DSR part from what once was the ip header (swap them)
+    memcpy(dsr_new, dsr_old, dsr_len);
+
+    // un-remove the headers
+    p = p->push(dsr_len);	// should never create a new packet
+    // clear VLAN_ANNO
+    SET_VLAN_ANNO(p, 0);
+
+    memcpy(p->data(), &new_ip, sizeof(click_ip));
+    ip=reinterpret_cast<click_ip *>(p->data());
+    ip->ip_len=htons(p->length());
+    ip->ip_sum=0;
+    ip->ip_sum=click_in_cksum((unsigned char *)ip,sizeof(click_ip));
+
+    p->set_ip_header((click_ip*)p->data(),sizeof(click_ip));
+
+    // click_chatter("UnstripDSR: Added %d bytes\n", dsr_len);
+
+    return p;
+}
+
+CLICK_ENDDECLS
+EXPORT_ELEMENT(UnstripDSRHeader)
+ELEMENT_MT_SAFE(UnstripDSRHeader)

--- a/elements/grid/unstripdsrheader.hh
+++ b/elements/grid/unstripdsrheader.hh
@@ -1,0 +1,31 @@
+#ifndef CLICK_UNSTRIPDSRHEADER_HH
+#define CLICK_UNSTRIPDSRHEADER_HH
+#include <click/element.hh>
+CLICK_DECLS
+
+/*
+ * =c
+ * UnstripDSRHeader()
+ * =s ip
+ * restores DSR Header
+ * =d
+ *
+ * Undoes StripDSRHeader: Swaps the IP and the DSR header a second time,
+ * pushes the dsr_len offset previously saved to VLAN_ANNO.
+ *
+ * =a CheckDSRHeader, MarkDSRHeader, StripDSRHeader */
+
+class UnstripDSRHeader : public Element { public:
+
+  UnstripDSRHeader();
+  ~UnstripDSRHeader();
+
+  const char *class_name() const		{ return "UnstripDSRHeader"; }
+  const char *port_count() const		{ return PORTS_1_1; }
+
+  Packet *simple_action(Packet *);
+
+};
+
+CLICK_ENDDECLS
+#endif


### PR DESCRIPTION
These elements allow fiddling with the payload of DSR data packets, by stripping / saving away the DSR header and later reversing the process.
