### PR TITLE
CheckUDPHeader and CheckTCPHeader drop details not initialized during configure.

### DIFF
--- a/elements/tcpudp/checktcpheader.cc
+++ b/elements/tcpudp/checktcpheader.cc
@@ -55,8 +55,11 @@ CheckTCPHeader::configure(Vector<String> &conf, ErrorHandler *errh)
     return -1;
 
   _verbose = verbose;
-  if (details)
+  if (details) {
     _reason_drops = new atomic_uint32_t[NREASONS];
+    for (int i = 0; i < NREASONS; ++i)
+      _reason_drops[i] = 0;
+  }
 
   return 0;
 }

--- a/elements/tcpudp/checkudpheader.cc
+++ b/elements/tcpudp/checkudpheader.cc
@@ -54,8 +54,11 @@ CheckUDPHeader::configure(Vector<String> &conf, ErrorHandler *errh)
     return -1;
 
   _verbose = verbose;
-  if (details)
+  if (details) {
     _reason_drops = new atomic_uint32_t[NREASONS];
+    for (int i = 0; i < NREASONS; ++i)
+      _reason_drops[i] = 0;
+  }
 
   return 0;
 }


### PR DESCRIPTION
Commit initializes _reason_drops[] to 0, currently it displays random values when used.
Initially I wanted to use memset, but kept with what CheckIPHeader is using.
