### PR TITLE
classification.cc: fix bug in DominatorOptimizer

### DIFF
--- a/elements/standard/classification.cc
+++ b/elements/standard/classification.cc
@@ -627,7 +627,9 @@ DominatorOptimizer::shift_branch(int state, bool branch)
 	return;
     int br = brno(state, branch);
 
-    if (_domlist_start[state] + 1 == _domlist_start[state+1]) {
+    if (_domlist_start[state] == _domlist_start[state+1])
+	return;
+    else if (_domlist_start[state] + 1 == _domlist_start[state+1]) {
 	// single domlist; faster algorithm
 	int d = _domlist_start[state];
 	new_nexts = dom_shift_branch(br, nexts, _dom_start[d], _dom_start[d+1], 0);


### PR DESCRIPTION
Without this change, this config will fail the assertion at the start of
DominatorOptimizer::last_common_state_in_lists.

Idle
-> ipf :: IPFilter(allow tcp && dst 10.0.0.0/32 && src 2.0.0.0/32,
                   allow tcp && dst 10.0.0.0/32 && dst port 80 && src 2.0.0.0/32,
                   allow all)
-> Discard;

I can confess that I do not actually understand the code involved enough well
enough to know if this is the best fix, however it seems like it is safe to me.
I am also unsure of a good test case to add.  I can add the above, but it is
incredibly fragile... reordering or removing anything in it seems to be enough
to make it stop failing.
