### PR TITLE
click: Compatibility changes for kernel lock debugging

### DIFF
--- a/linuxmodule/fixincludes.pl
+++ b/linuxmodule/fixincludes.pl
@@ -174,11 +174,6 @@ sub one_includeroot ($$) {
 	    s{([\{,]\s*)\.\s*([a-zA-Z_]\w*)\s*=}{$1$2: }g;
 	    s{([\{,]\s*\\\n\s*)\.\s*([a-zA-Z_]\w*)\s*=}{$1$2: }g;
 
-	    # ktime initializers
-	    s{(return|=)\s*\((\w+)\)\s*(\{[^\{\}]*\})}{$1 \(\{ $2 __magic_$2__ = $3; __magic_$2__; \}\)}g;
-	    s{(return|=)\s*\((\w+)\)\s*(\{[^\{\}]*\{[^\{\}]*\}[^\{\}]*\})}{$1 \(\{ $2 __magic_$2__ = $3; __magic_$2__; \}\)}g;
-	    s{\(struct\s+(\w+)\)\s*(__.*\(.*?\));}{\(\{ struct $1 __magic_$1__ = $2; __magic_$1__; \}\);}g;
-
 	    # "new" and other keywords
 	    s{\bnew\b}{new_value}g;
 	    s{\band\b}{and_value}g;
@@ -227,6 +222,18 @@ sub one_includeroot ($$) {
 	    }
 	    if ($d eq "netdevice.h") {
 		1 while (s<(^struct net_device \{[\000-\377]*)^\tenum( \{[^}]*\}) (\w+)><enum net_device_$3$2;\n$1\tenum net_device_$3 $3>mg);
+	    }
+
+	    # ktime initializers
+	    if ($d eq "ktime.h") {
+		s{(return|=)\s*\((\w+)\)\s*(\{[^\{\}]*\})}{$1 \(\{ $2 __magic_$2__ = $3; __magic_$2__; \}\)}g;
+		s{(return|=)\s*\((\w+)\)\s*(\{[^\{\}]*\{[^\{\}]*\}[^\{\}]*\})}{$1 \(\{ $2 __magic_$2__ = $3; __magic_$2__; \}\)}g;
+		s{\(struct\s+(\w+)\)\s*(__.*\(.*?\));}{\(\{ struct $1 __magic_$1__ = $2; __magic_$1__; \}\);}g;
+	    }
+
+	    if ($d eq "semaphore.h") {
+		s{(static inline void sema_init)}{#ifndef __cplusplus\n$1};
+	        s/(lockdep.*})/$1\n#endif\n/s;
 	    }
 
 	    # CLICK_CXX_PROTECTED check


### PR DESCRIPTION
Lock correctness debugging requires that various kernel data structures
be statically allocated, instead of being allocated in dynamic
memory. One such structre is the VFS file_system_type.

Previously, proclikefs imbedded this structure inside its
proclikefs_file_system structure, which was allocated dynamically.
Instead, each client of proclikefs (actually just clickfs) now
statically allocates a file_system_type structure, and registers
this with proclikefs.

The include file semaphore.h contains a C99-style structure
initializer which is not legal in C++. This file only gets
included when spin lock debugging is enabled. Since Click does
not use sema_init(), the simple fix is to skip its compilation
by surrounding it in #ifndef __cplusplus.

The include file semaphore.h is also mangled by the fixincludes.pl
changes which are intended to only modify ktime.h. Limit the scope
of ktime-related changes to only ktime.h
