### PR TITLE
Fix a segfault for cpSize type in cp_va_kparse

### DIFF
--- a/elements/test/confparsetest.cc
+++ b/elements/test/confparsetest.cc
@@ -418,6 +418,13 @@ ConfParseTest::initialize(ErrorHandler *errh)
     CHECK(click_strcmp("a1.2", "a1a") > 0);
 #endif
 
+    Vector<String> conf;
+    conf.push_back("SIZE 123456789");
+    size_t test_size;
+    CHECK(cp_va_kparse(conf, this, errh,
+                       "SIZE", 0, cpSize, &test_size,
+                       cpEnd) == 1 && test_size == 123456789);
+
     errh->message("All tests pass!");
     return 0;
 }

--- a/lib/confparse.cc
+++ b/lib/confparse.cc
@@ -2948,7 +2948,7 @@ default_storefunc(cp_value *v  CP_CONTEXT)
 
   case cpiSize: {
       size_t *sizestore = (size_t *) v->store;
-      *sizestore = *((size_t *) v->v.size);
+      *sizestore = v->v.size;
       break;
   }
 


### PR DESCRIPTION
Instead of copying the size_t value, the value was being used as a
pointer to the size_t value, causing a bad memory read.
