### PR TITLE
(To/From)UserDevice: cleanups, fixups, features

### DIFF
--- a/elements/linuxmodule/touserdevice.cc
+++ b/elements/linuxmodule/touserdevice.cc
@@ -1,6 +1,6 @@
 /*
 
-Programmer: Roman Chertov
+Programmer: Roman Chertov, Cliff Frey
 
 All files in this distribution of are Copyright 2006 by the Purdue
 Research Foundation of Purdue University. All rights reserved.
@@ -17,6 +17,9 @@ specific prior written permission. THIS SOFTWARE IS PROVIDED ``AS IS''
 AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, WITHOUT
 LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 ANY PARTICULAR PURPOSE.
+
+Copyright (c) 2011 Meraki, Inc.
+
 */
 
 #include <click/config.h>
@@ -28,46 +31,51 @@ ANY PARTICULAR PURPOSE.
 
 #include <click/cxxprotect.h>
 CLICK_CXX_PROTECT
-#include <linux/mm.h>
-#include <linux/module.h>
-#include <linux/version.h>
 #include <linux/poll.h>
+#include <linux/wait.h>
+#include <linux/sched.h>
 #include <linux/fs.h>
-#include <asm/types.h>
 #include <asm/uaccess.h>
-#include <linux/ip.h>
-#include <linux/inetdevice.h>
-#include <net/route.h>
 CLICK_CXX_UNPROTECT
 #include <click/cxxunprotect.h>
 
 #include "touserdevice.hh"
-#include <click/hashmap.hh>
-#include <click/llrpc.h>
+#include "fromuserdevice.hh"
 
 
-static char DEV_NAME[] = "touser";
-static int  DEV_MAJOR = 241;
-static int  DEV_MINOR = 0;
-static int  DEV_NUM = 0;
+static const char DEV_NAME[] = "click_user";
+static int DEV_MAJOR = 241;
+static int DEV_NUM = 0;
 
 struct file_operations *ToUserDevice::dev_fops;
 
+volatile ToUserDevice *ToUserDevice::elem_map[256] = {0};
 
-static volatile ToUserDevice *elem[20] = {0};
+struct pcap_hdr {
+    uint32_t magic_number;   /* magic number */
+    uint16_t version_major;  /* major version number */
+    uint16_t version_minor;  /* minor version number */
+    int32_t  thiszone;	     /* GMT to local correction */
+    uint32_t sigfigs;	     /* accuracy of timestamps */
+    uint32_t snaplen;	     /* max length of captured packets, in octets */
+    uint32_t network;	     /* data link type */
+};
 
+struct pcaprec_hdr {
+    uint32_t ts_sec;	     /* timestamp seconds */
+    uint32_t ts_usec;	     /* timestamp microseconds */
+    uint32_t incl_len;	     /* number of octets of packet saved in file */
+    uint32_t orig_len;	     /* actual length of packet */
+};
 
 ToUserDevice::ToUserDevice() : _task(this)
 {
     _exit = false;
     _size = 0;
-    _capacity = default_capacity;
-    _devname = DEV_NAME;
     _q = 0;
     _r_slot = 0;
     _w_slot = 0;
     _dev_major = DEV_MAJOR;
-    _dev_minor = DEV_MINOR;
     _read_count = 0;
     _drop_count = 0;
     _sleep_proc = 0;
@@ -75,280 +83,406 @@ ToUserDevice::ToUserDevice() : _task(this)
     _block_count = 0;
     _pkt_read_count = 0;
     _failed_count = 0;
+    _from_user_device = 0;
 }
 
 ToUserDevice::~ToUserDevice()
 {
-
 }
 
 extern struct file_operations *click_new_file_operations();
 
-void ToUserDevice::static_initialize()
+void
+ToUserDevice::static_initialize()
 {
     if ((dev_fops = click_new_file_operations())) {
-	dev_fops->read    = dev_read;
-	dev_fops->poll    = dev_poll;
-	dev_fops->open    = dev_open;
+	dev_fops->read	  = dev_read;
+	dev_fops->write	  = dev_write;
+	dev_fops->poll	  = dev_poll;
+	dev_fops->open	  = dev_open;
 	dev_fops->release = dev_release;
-	dev_fops->ioctl	  = dev_ioctl;
     }
 }
 
-void ToUserDevice::static_cleanup()
+void
+ToUserDevice::static_cleanup()
 {
     dev_fops = 0;		// proclikefs will free eventually
 }
 
-#define GETELEM(filp)		((ToUserDevice *) ((uintptr_t) filp->private_data & ~(uintptr_t) 1))
+#define GETELEM(filp)		((ToUserDevice *) (((struct file_priv *)filp->private_data)->dev));
 
 // open function - called when the "file" /dev/toclick is opened in userspace
-int ToUserDevice::dev_open(struct inode *inode, struct file *filp)
+int
+ToUserDevice::dev_open(struct inode *inode, struct file *filp)
 {
     int num = MINOR(inode->i_rdev); // low order number
-    click_chatter("**ToUserDevice_open %d\n", num);
-    if (!elem[num])
-    {
-        click_chatter("No ToUserDevice element for this device: %d\n", num);
-        return -EIO;
+    if (!elem_map[num]) {
+	click_chatter("No ToUserDevice element for this device: %d\n", num);
+	return -EIO;
     }
-    filp->private_data = (void *) elem[num];
+    //struct file_priv *f = (struct file_priv *)kmalloc(sizeof(struct file_priv), GFP_KERNEL);
+    file_priv *f = (file_priv *) kmalloc(sizeof(struct file_priv), GFP_ATOMIC);
+    f->dev = (ToUserDevice*)elem_map[num];
+    f->read_once = 0;
+    f->p = 0;
+    filp->private_data = (void *)f;
     return 0;
 }
 
 // close function - called when the "file" /dev/toclick is closed in userspace
-int ToUserDevice::dev_release(struct inode *inode, struct file *filp)
+int
+ToUserDevice::dev_release(struct inode *inode, struct file *filp)
 {
     ToUserDevice *elem = GETELEM(filp);
     if (!elem) {
-        click_chatter("Empty private struct!\n");
-        return -EIO;
+	click_chatter("Empty private struct!\n");
+	return -EIO;
     }
-    click_chatter("ToUserDevice_release ReadCounter: %lu\n", elem->_read_count);
+    kfree(filp->private_data);
     return 0;
 }
 
-int ToUserDevice::dev_ioctl(struct inode *inode, struct file *filp,
-			    unsigned command, unsigned long address)
+ssize_t
+ToUserDevice::dev_write(struct file *filp, const char *buff, size_t len, loff_t *ppos)
 {
     ToUserDevice *elem = GETELEM(filp);
-    if (elem->_exit)
-	return -EIO;
-    else if (command == CLICK_IOC_TOUSERDEVICE_GET_MULTI)
-	return ((uintptr_t) filp->private_data) & 1;
-    else if (command == CLICK_IOC_TOUSERDEVICE_SET_MULTI) {
-	if ((int) address != 0 && (int) address != 1)
-            return -EINVAL;
-	filp->private_data = (void *) ((uintptr_t) elem | (int) address);
-	return 0;
-    } else
-	return -EINVAL;
+    FromUserDevice *fud = elem->_from_user_device;
+    if (!fud)
+	return -EPERM;
+
+    return fud->dev_write(buff, len, ppos);
 }
 
-ssize_t ToUserDevice::dev_read(struct file *filp, char *buff, size_t len, loff_t *ppos)
+ssize_t
+ToUserDevice::dev_read(struct file *filp, char *buff, size_t len, loff_t *ppos)
 {
     ToUserDevice *elem = GETELEM(filp);
-    int multi = ((uintptr_t) filp->private_data) & 1;
-    int err;
-    // there is a private field and that doesn't compile in C++ so we can't use DEFINE_WAIT macro
-    wait_queue_t wq;
-#include <click/cxxprotect.h>
-    init_wait(&wq);
-#include <click/cxxunprotect.h>
+    file_priv *f = (file_priv *)filp->private_data;
+    unsigned nfetched = 0;
+    ssize_t nread = 0;
 
-    spin_lock(&elem->_lock); // LOCK
     elem->_read_count++;
-    while (!elem->_size && !elem->_exit) {
-	// need to put the process to sleep
-	elem->_block_count++;
-	elem->_sleep_proc++;
-	prepare_to_wait(&elem->_proc_queue, &wq, TASK_INTERRUPTIBLE);
-	spin_unlock(&elem->_lock); // UNLOCK
-	schedule();
-	finish_wait(&elem->_proc_queue, &wq);
-	if (elem->_exit)
-	    return -EIO;
-	spin_lock(&elem->_lock); // LOCK
-	elem->_sleep_proc--;
+
+    if (elem->_debug)
+	printk("read %d pkt %p\n", f->read_once, f->p);
+
+    if (f->read_once == 0 && elem->_encap_type == type_encap_pcap) {
+	/* on initial read, write out the pcap header */
+	Packet *p = Packet::make(sizeof(struct pcap_hdr));
+	if (!p)
+	    return -ENOMEM;
+	nfetched++;
+	struct pcap_hdr *hdr = (struct pcap_hdr *)p->data();
+	memset(hdr, 0, sizeof(struct pcap_hdr));
+	hdr->magic_number = htonl(0xa1b2c3d4);
+	hdr->version_major = htons(2);
+	hdr->version_minor = htons(4);
+	hdr->thiszone = htonl(0);
+	hdr->sigfigs = htonl(0);
+	hdr->snaplen = htonl(elem->_pcap_snaplen);
+	hdr->network = htonl(elem->_pcap_network);
+	f->p = p;
+	f->read_once = 1;
+	if (elem->_debug)
+	    printk("%s:%d copied header\n", __func__, __LINE__);
     }
 
-    ssize_t nread = 0;
-    unsigned nfetched = 0;
+    if (f->p) {
+	Packet *p = f->p;
+	ssize_t to_copy = p->length();
+	if (to_copy > len)
+	    to_copy = len;
+	if (copy_to_user(buff, p->data(), to_copy)) {
+	    elem->_failed_count++;
+	    click_chatter("%{element}: Read Fault", elem);
+	    p->kill();
+	    return -EFAULT;
+	}
+	nread += to_copy;
+	if (to_copy < p->length()) {
+	    p->pull(nread);
+	} else if (to_copy == p->length()) {
+	    p->kill();
+	    f->p = 0;
+	}
+	if (nread == len || elem->_type == type_packet)
+	    return nread;
+    }
+
+    spin_lock(&elem->_lock); // LOCK
+    if (!nread && elem->_blocking) {
+	if ((filp->f_flags & O_NONBLOCK) && !elem->_size) {
+	    spin_unlock(&elem->_lock); // UNLOCK
+	    return -EAGAIN;
+	}
+
+	// there is a private field and that doesn't compile in C++ so we can't use DEFINE_WAIT macro
+	wait_queue_t wq;
+#include <click/cxxprotect.h>
+	init_wait(&wq);
+#include <click/cxxunprotect.h>
+	while (!elem->_size && !elem->_exit) {
+	    // need to put the process to sleep
+	    elem->_block_count++;
+	    elem->_sleep_proc++;
+	    prepare_to_wait(&elem->_proc_queue, &wq, TASK_INTERRUPTIBLE);
+	    if (elem->_size || elem->_exit) {
+		finish_wait(&elem->_proc_queue, &wq);
+		break;
+	    }
+	    spin_unlock(&elem->_lock); // UNLOCK
+	    if (signal_pending(current)) {
+		finish_wait(&elem->_proc_queue, &wq);
+		return -ERESTARTSYS;
+	    }
+	    schedule();
+	    spin_lock(&elem->_lock); // LOCK
+	    elem->_sleep_proc--;
+	}
+	if (elem->_exit) {
+	    spin_unlock(&elem->_lock); // UNLOCK
+	    return -EIO;
+	}
+    }
+
     while (elem->_size
-	   && (nfetched == 0 || multi)
 	   && (nfetched < elem->_max_burst || elem->_max_burst == 0)
 	   && nread < len
 	   && !elem->_exit) {
-	Packet *p = elem->_q[elem->_r_slot];
-	// user buffer is full
-	if (nfetched > 0 && nread + sizeof(int) + p->length() > len)
-	    break;
-	elem->_r_slot++;
-	if (elem->_r_slot == elem->_capacity)
-	    elem->_r_slot = 0;
-	elem->_size--;
-	spin_unlock(&elem->_lock);
+	nfetched++;
+	Packet *p = elem->pop_packet();
+	spin_unlock(&elem->_lock); // UNLOCK
 	// unlock as don't need the lock, and can't have a lock and copy_to_user
-
-	// copy packet to user level
-	if (multi) {
-	    int len = p->length();
-	    if (copy_to_user(buff + nread, &len, sizeof(int))) {
-		elem->_failed_count++;
-		click_chatter("Read Fault");
-		p->kill();
-		return -EFAULT;
-	    }
-	    nread += sizeof(int);
-	}
-
 	ssize_t to_copy = p->length();
 	if (to_copy > len - nread)
 	    to_copy = len - nread;
 	if (copy_to_user(buff + nread, p->data(), to_copy)) {
 	    elem->_failed_count++;
-	    click_chatter("Read Fault");
+	    click_chatter("%{element}: Read Fault", elem);
 	    p->kill();
 	    return -EFAULT;
 	}
 	nread += to_copy;
-
-	// to get int alignment
-	if (multi && nread % sizeof(int))
-	    nread += sizeof(int) - nread % sizeof(int);
-
-	p->kill();
-	spin_lock(&elem->_lock);
-	nfetched++;
-        elem->_pkt_read_count++;
+	if (elem->_type == type_stream && to_copy < p->length()) {
+	    p->pull(to_copy);
+	    f->p = p;
+	} else {
+	    p->kill();
+	}
+	spin_lock(&elem->_lock); // LOCK
+	elem->_pkt_read_count++;
     }
 
     if (nread == 0 && elem->_exit)
 	nread = -EIO;
-    spin_unlock(&elem->_lock);
+
+    spin_unlock(&elem->_lock); // UNLOCK
     return nread;
 }
 
-uint ToUserDevice::dev_poll(struct file *filp, struct poll_table_struct *pt)
+uint
+ToUserDevice::dev_poll(struct file *filp, struct poll_table_struct *pt)
 {
     ToUserDevice *elem = GETELEM(filp);
-    uint    mask = 0;
+    uint mask = 0;
 
-    //click_chatter("ToUserDevice_poll\n");
-    if (!elem || elem->_exit)
-	return mask;
-
+    if (!elem)
+	return 0;
     poll_wait(filp, &elem->_proc_queue, pt);
+
+    FromUserDevice *fud = elem->_from_user_device;
+    if (fud)
+	mask |= fud->dev_poll();
+
     spin_lock(&elem->_lock); // LOCK
-    if (elem->_size)
+    if (elem->_exit || !elem->_blocking || elem->_size)
     {
-        mask |= POLLIN | POLLRDNORM; /* readable */
-        //click_chatter("ToUserDevice_poll Readable\n");
+	mask |= POLLIN | POLLRDNORM; /* readable */
+	//click_chatter("ToUserDevice_poll Readable\n");
     }
     spin_unlock(&elem->_lock); // UNLOCK
     return mask;
 }
 
-int ToUserDevice::configure(Vector<String> &conf, ErrorHandler *errh)
+int
+ToUserDevice::configure(Vector<String> &conf, ErrorHandler *errh)
 {
-    int          res;
-    dev_t        dev;
+    int		 res;
+    dev_t	 dev;
 
-    //click_chatter("CONFIGURE\n");
     if (!dev_fops)
 	return errh->error("file operations missing");
 
-    _max_burst = 0;
+    _pcap_network = 1;
+    _pcap_snaplen = 65535;
+    _debug = false;
+    _drop_tail = true;
+    _blocking = true;
+    _max_burst = 1;
+    _capacity = default_capacity;
+    String encap = String::make_stable("none");
+    String type;
     if (Args(conf, this, errh)
 	.read_mp("DEV_MINOR", _dev_minor)
 	.read("CAPACITY", _capacity)
 	.read("BURST", _max_burst)
+	.read("TYPE", WordArg(), type)
+	.read("ENCAP", WordArg(), encap)
+	.read("PCAP_NETWORK", _pcap_network)
+	.read("PCAP_SNAPLEN", _pcap_snaplen)
+	.read("DEBUG", _debug)
+	.read("BLOCKING", _blocking)
+	.read("DROP_TAIL", _drop_tail)
 	.complete() < 0)
-        return -1;
+	return -1;
 
+    if (_dev_minor >= 256)
+	return errh->error("DEV_MINOR number too high");
+
+    if (encap == "none")
+	_encap_type = type_encap_none;
+    else if (encap == "pcap")
+	_encap_type = type_encap_pcap;
+    else if (encap == "len32")
+	_encap_type = type_encap_len32;
+    else if (encap == "len_net16")
+	_encap_type = type_encap_len_net16;
+    else
+	return errh->error("bad ENCAP type");
+
+    if (type == "packet")
+	_type = type_packet;
+    else if (type == "stream")
+	_type = type_stream;
+    else if (!type)
+	_type = (_encap_type == type_encap_none) ? type_packet : type_stream;
+    else
+	return errh->error("bad TYPE (must be packet or stream)");
 
     spin_lock_init(&_lock); // LOCK INIT
     if (!(_q = (Packet **)click_lalloc(_capacity * sizeof(Packet *))))
     {
-        click_chatter("ToUserDevice Failed to alloc %lu slots\n", _capacity);
-        return -1;
+	click_chatter("ToUserDevice Failed to alloc %lu slots\n", _capacity);
+	return -1;
     }
     _dev_major = DEV_MAJOR;
     DEV_NUM++;
     if (DEV_NUM == 1)
     {
-        // time to associate the devname with this class
+	// time to associate the devname with this class
 
-        //register the device now. this will register 255 minor numbers
-        res = register_chrdev(_dev_major, DEV_NAME, dev_fops);
-        if (res < 0)
-        {
-            click_chatter("Failed to Register Dev:%s Major:%d Minor:%d\n",
-                DEV_NAME, _dev_major, _dev_minor);
-            click_lfree((char*)_q, _capacity * sizeof(Packet *));
-            _q = 0;
-            return - EIO;
-        }
+	//register the device now. this will register 255 minor numbers
+	res = register_chrdev(_dev_major, DEV_NAME, dev_fops);
+	if (res < 0)
+	{
+	    click_chatter("Failed to Register Dev:%s Major:%d Minor:%d\n",
+		DEV_NAME, _dev_major, _dev_minor);
+	    click_lfree((char*)_q, _capacity * sizeof(Packet *));
+	    _q = 0;
+	    return - EIO;
+	}
     }
-    elem[_dev_minor] = this;
+    elem_map[_dev_minor] = this;
     init_waitqueue_head(&_proc_queue);
-    click_chatter("Dev:%s Major: %d Minor: %d Size:%d\n", _devname.c_str(), _dev_major, _dev_minor, _size);
     return 0;
 }
 
-int ToUserDevice::initialize(ErrorHandler *errh)
+int
+ToUserDevice::initialize(ErrorHandler *errh)
 {
-    click_chatter("**ToUserDevice init\n");
     if (input_is_pull(0))
     {
-        ScheduleInfo::initialize_task(this, &_task, errh);
-        _signal = Notifier::upstream_empty_signal(this, 0, &_task);
+	ScheduleInfo::initialize_task(this, &_task, errh);
+	_signal = Notifier::upstream_empty_signal(this, 0, &_task);
     }
     return 0;
 }
 
-//cleanup
-void ToUserDevice::cleanup(CleanupStage stage)
+void
+ToUserDevice::cleanup(CleanupStage stage)
 {
-    //click_chatter("cleanup...");
     if (stage < CLEANUP_CONFIGURED)
-        return; // have to quit, as configure was never called
+	return; // have to quit, as configure was never called
     spin_lock(&_lock); // LOCK
     DEV_NUM--;
     _exit = true; // signal for exit
     spin_unlock(&_lock); // UNLOCK
+
     if (_q) {
-        //click_chatter(" Start ");
-        wake_up_interruptible(&_proc_queue);
+	wake_up_interruptible(&_proc_queue);
 	while (waitqueue_active(&_proc_queue))
 	    schedule();
 
-        // I guess after this, god knows what will happen to procs that are
-        // blocked
-        if (!DEV_NUM)
-            unregister_chrdev(_dev_major, DEV_NAME);
-        // now clear out the memory
-	while (_size > 0) {
-	    _q[_r_slot]->kill();
-	    _r_slot++;
-	    if (_r_slot == _capacity)
-		_r_slot = 0;
-	    _size--;
-	}
-        click_lfree((char*)_q, _capacity * sizeof(Packet *));
+	if (!DEV_NUM)
+	    unregister_chrdev(_dev_major, DEV_NAME);
+
+	reset();
+	click_lfree((char*)_q, _capacity * sizeof(Packet *));
     }
-    //click_chatter("cleanup Done. ");
 }
 
-bool ToUserDevice::process(Packet *p)
+void
+ToUserDevice::reset()
 {
+    spin_lock(&_lock); // LOCK
+    // now clear out the memory
+    while (_size > 0) {
+	_q[_r_slot]->kill();
+	_r_slot++;
+	if (_r_slot == _capacity)
+	    _r_slot = 0;
+	_size--;
+    }
+    spin_unlock(&_lock); // UNLOCK
+}
+
+bool
+ToUserDevice::process(Packet *p)
+{
+    if (_encap_type != type_encap_none) {
+	WritablePacket *wp = p->uniqueify();
+	if (unlikely(!wp))
+	    return false;
+	if (_encap_type == type_encap_pcap) {
+	    int orig_len = wp->length();
+	    int this_len = wp->length();
+	    if (this_len > _pcap_snaplen) {
+		this_len = _pcap_snaplen;
+		wp->take(wp->length() - _pcap_snaplen);
+	    }
+	    wp->push(sizeof(struct pcaprec_hdr));
+	    struct pcaprec_hdr *h = (struct pcaprec_hdr *)wp->data();
+	    memset(h, 0, sizeof(struct pcaprec_hdr));
+	    Timestamp t = wp->timestamp_anno();
+	    h->ts_sec = htonl(t.sec());
+	    h->ts_usec = htonl(t.usec());
+	    h->incl_len = htonl(this_len);
+	    h->orig_len = htonl(orig_len);
+	} else if (_encap_type == type_encap_len32) {
+	    wp->push(sizeof(uint32_t));
+	    uint32_t len = wp->length();
+	    memcpy(wp->data(), &len, sizeof(uint32_t));
+	} else if (_encap_type == type_encap_len_net16) {
+	    wp->push(sizeof(uint16_t));
+	    uint16_t len = htons(wp->length());
+	    memcpy(wp->data(), &len, sizeof(uint16_t));
+	}
+	p = wp;
+    }
+
     spin_lock(&_lock);
     _pkt_count++;
+
     if (_size >= _capacity) {
 	_drop_count++;
-	p->kill();
-	spin_unlock(&_lock);
-	return false;
+	if (_drop_tail)
+	    pop_packet()->kill();
+	else {
+	    p->kill();
+	    spin_unlock(&_lock);
+	    return false;
+	}
     }
 
     _q[_w_slot] = p;
@@ -362,62 +496,83 @@ bool ToUserDevice::process(Packet *p)
     return true;
 }
 
-void ToUserDevice::push(int, Packet *p)
+void
+ToUserDevice::push(int, Packet *p)
 {
-    if (p)
-	process(p);
+    process(p);
 }
 
 // something is upstream so we can run
-bool ToUserDevice::run_task(Task *)
+bool
+ToUserDevice::run_task(Task *)
 {
     Packet *p = input(0).pull();
-    int     res;
 
     if (p)
-        process(p);
+	process(p);
     else if (!_signal)
-        return false;
+	return false;
     _task.fast_reschedule();
     return p != 0;
 }
 
-enum { H_COUNT, H_DROPS, H_READ_CALLS, H_CAPACITY,
-       H_READ_COUNT, H_SIZE, H_BLOCKS, H_FAILED};
-
-String ToUserDevice::read_handler(Element *e, void *thunk)
+Packet *
+ToUserDevice::pop_packet()
 {
-    ToUserDevice *c = (ToUserDevice *)e;
-
-    switch ((intptr_t)thunk)
-    {
-        case H_COUNT:      return String(c->_pkt_count);
-        case H_FAILED:      return String(c->_failed_count);
-        case H_BLOCKS:      return String(c->_block_count);
-        case H_SIZE:       return String(c->_size);
-        case H_DROPS:      return String(c->_drop_count);
-        case H_READ_CALLS: return String(c->_read_count);
-        case H_READ_COUNT: return String(c->_pkt_read_count);
-        case H_CAPACITY:   return String(c->_capacity);
-        default:           return "<error>";
+    Packet *p = 0;
+    if (_size > 0) {
+	p = _q[_r_slot];
+	_r_slot++;
+	if (_r_slot == _capacity)
+	    _r_slot = 0;
+	_size--;
     }
+    return p;
 }
 
-void ToUserDevice::add_handlers()
+int
+ToUserDevice::write_handler(const String &s_in, Element *e, void *thunk, ErrorHandler *errh)
 {
-    add_read_handler("count", read_handler, (void *)H_COUNT);
-    add_read_handler("failed", read_handler, (void *)H_FAILED);
-    add_read_handler("blocks", read_handler, (void *)H_BLOCKS);
-    add_read_handler("size", read_handler, (void *)H_SIZE);
-    add_read_handler("drops", read_handler, (void *)H_DROPS);
-    add_read_handler("reads", read_handler, (void *)H_READ_CALLS);
-    add_read_handler("pkt_reads", read_handler, (void *)H_READ_COUNT);
-    add_read_handler("capacity", read_handler, (void *)H_CAPACITY);
+    ToUserDevice *td = (ToUserDevice *)e;
+    String s = cp_uncomment(s_in);
+    switch ((intptr_t)thunk) {
+    case h_reset: {
+	td->reset();
+	break;
+    }
+    }
+    return 0;
+}
+
+void
+ToUserDevice::add_handlers()
+{
+    add_data_handlers("count", Handler::OP_READ, &_pkt_count);
+    add_data_handlers("size", Handler::OP_READ, &_size);
+    add_data_handlers("drops", Handler::OP_READ, &_drop_count);
+    add_data_handlers("capacity", Handler::OP_READ, &_capacity);
+    add_data_handlers("read_count", Handler::OP_READ, &_read_count);
+    add_data_handlers("read_fail_count", Handler::OP_READ, &_failed_count);
+    add_data_handlers("pkt_read_count", Handler::OP_READ, &_pkt_read_count);
+    add_data_handlers("drop_count", Handler::OP_READ, &_drop_count);
+    add_data_handlers("block_count", Handler::OP_READ, &_block_count);
+    add_data_handlers("sleeping_proc", Handler::OP_READ, &_sleep_proc);
+
+    add_write_handler("reset", write_handler, (void *) h_reset);
+    add_data_handlers("debug", Handler::OP_READ | Handler::OP_WRITE, &_debug);
+    add_data_handlers("drop_tail", Handler::OP_READ | Handler::OP_WRITE, &_drop_tail);
+    add_data_handlers("burst", Handler::OP_READ | Handler::OP_WRITE, &_max_burst);
+
+    if (_encap_type == type_encap_pcap) {
+	add_data_handlers("pcap_snaplen", Handler::OP_READ | Handler::OP_WRITE, &_pcap_snaplen);
+	add_data_handlers("pcap_network", Handler::OP_READ | Handler::OP_WRITE, &_pcap_network);
+    }
+
     if (input_is_pull(0))
-        add_task_handlers(&_task);
+	add_task_handlers(&_task);
 }
 
 
-ELEMENT_REQUIRES(linuxmodule experimental)
+ELEMENT_REQUIRES(linuxmodule experimental FromUserDevice)
 EXPORT_ELEMENT(ToUserDevice)
 ELEMENT_MT_SAFE(ToUserDevice)

--- a/elements/linuxmodule/touserdevice.hh
+++ b/elements/linuxmodule/touserdevice.hh
@@ -1,26 +1,41 @@
 #ifndef CLICK_TOUSERDEVICE_HH
 #define CLICK_TOUSERDEVICE_HH
 #include <click/element.hh>
-#include <click/etheraddress.hh>
-#include <click/timer.hh>
 #include <click/notifier.hh>
+#include <click/atomic.hh>
 
 #include <click/cxxprotect.h>
 CLICK_CXX_PROTECT
-#include <asm/types.h>
-#include <linux/fs.h>
-#include <linux/netdevice.h>
-#include <linux/route.h>
+#include <linux/wait.h>
 CLICK_CXX_UNPROTECT
 #include <click/cxxunprotect.h>
 
 /*
 =c
-ToUserDevice(DEV_MINOR, [<keywords> CAPACITY, BURST])
+ToUserDevice(DEV_MINOR, [I<KEYWORDS>])
 
 =s netdevices
-Writes packets from the click into a device's ring buffer, which can be
-then read by a userlevel application.
+
+ToUserDevice provides a way to get packets from click running in linuxmodule
+into userspace through a character device.  This is a way of giving packets to a
+user process without going through linux's routing or networking code.
+Internally, ToUserDevice has a queue of packets.
+
+ToUserDevice can optionally apply encapsulation to the packets, either pcap
+encapsulation or length-delimited encapsulation.
+
+The character device can act like a datagram socket, where one packet is
+returned per read()/recv() call (but the packet may end up truncated), or it can
+act like a streaming socket where all packet data is reliably returned in a
+stream.  In order to reliably be able to detect packet boundaries, it makes the
+most sense to use one of the encapsulation types if using the streaming
+interface.
+
+In addition, ToUserDevice can run in a mode where reads will block until there
+is data available (the default mode) or it can run in a mode where read() will
+return 0 (end-of-file) if the device is empty.  This can be particularly useful
+with the pcap format where the character device will appear to be a valid pcap
+file.
 
 =d
 Requires --enable-experimental.
@@ -32,52 +47,65 @@ Keyword arguments are:
 =item CAPACITY
 
 Unsigned integer.  Sets the capacity of the internal ring buffer that stores
-the packets.
+the packets.  Defaults to 64.
+
+=item BLOCKING
+
+Boolean.  If true, then reads will block until there is data to return.  If
+false, reads when the ring buffer is empty will return 0.  Defaults to true.
+
+=item DROP_TAIL
+
+Boolean.  Sets the drop policy of this device if the ring buffer is currently
+full.  Defaults to true.
+
+=item ENCAP
+
+String.  Must be one of: none, pcap, len32, or len_net16.  Defaults to 'none.'
+Choosing pcap will cause each new open of the character device to first receive
+a valid pcap file header, and add individual pcap packet headers to each packet.
+len32 prepends a uint32 in host byte order before each packet with the packet's
+length.  len_net16 prepends a uint16 in network byte order before each packet
+with the packet's length.
+
+=item PCAP_NETWORK
+
+Unsigned integer.  When using 'ENCAP pcap', this changes the reported network
+type of the pcap file.  Defaults to 1 (Ethernet).
+
+=item PCAP_SNAPLEN
+
+Unsigned integer. This limits the amount of packet data returned by the 'pcap'
+encapsulation type.  Only affects the pcap type.  Defaults to 65535.
+
+=item TYPE
+
+String.  Must be one of 'packet' or 'stream'.  It defaults to 'packet' if ENCAP
+is 'none', and to 'stream' otherwise.
 
 =item BURST
 
-Sets the maximum number of packets returned per multipacket read.  Default is
-0, which means no limit.
+Unsigned integer. Sets the maximum number of packets returned per read.  Default
+is 1.  Zero means unlimited.  It is likely not wise to set this to anything
+except 1 if this is a 'TYPE packet' device.
+
+=item DEBUG
+
+Boolean.  Causes the element to print many debugging messages.  Defaults to
+false.
 
 =back
 
 The device must be first created in the /dev directory
-via mknod /dev/fromclickX c 241 X  where X is the minor device number (i.e. 0, 1, 2)
+via 'mknod /dev/fromclickX c 241 X' where X is the minor device number (i.e. 0, 1, 2)
 
 A user level application can then read directly from the device once it opens a file
 /dev/fromclickX
 
-The user level application must know what sort of packets are written into the device. (i.e.
-Eth frames, IP packets, etc.)
-
 =n
 
-=e
-
-  ... -> ToUserDevice(0, CAPACITY 200);
-
-Example how to read from the element in a userprogram when multi
-mode is enabled.
-
-   unsigned char buffer[BUFFERLEN];
-   ssize_t readlen = read(fd, buffer, BUFFERLEN);
-   for (ssize_t pos = 0; pos < readlen; ) {
-           int len = *(int*)(buffer + pos);
-           pos += sizeof(int);
-	   int stored_len = (len <= readlen - pos ? len : readlen - pos);
-
-           // At this point "buffer + pos" contains a packet that was "len"
-           // bytes long.  "stored_len" of those bytes are in the buffer.
-           process_packet(buffer + pos, len, stored_len);
-
-           // shift to next packet
-           pos += stored_len;
-           if (pos % sizeof(int))
-                   pos += sizeof(int) - pos % sizeof(int);
-   }
-
 =a
-ToUserDevice */
+FromUserDevice */
 
 
 class ToUserDevice : public Element
@@ -94,50 +122,72 @@ public:
     const char *port_count() const      { return PORTS_1_0; }
     const char *processing() const      { return PUSH; }
 
-
     int    configure(Vector<String> &, ErrorHandler *);
-    bool   process(Packet *);
+    int    configure_phase() const      { return CONFIGURE_PHASE_DEFAULT - 1; }
     bool   run_task(Task *);
     int    initialize(ErrorHandler *);
     void   cleanup(CleanupStage);
     void   add_handlers();
     void   push(int, Packet *);
-    static String read_handler(Element *e, void *thunk);
 
 private:
+    struct file_priv {
+        ToUserDevice *dev;
+        uint8_t read_once;
+        Packet *p;
+    };
+
+    Packet *pop_packet();
+    bool   process(Packet *);
+    void   reset();
+
     enum { default_capacity = 64 };
+    enum { h_reset };
 
     Packet **	    _q;
     uint32_t	    _size;
     uint32_t	    _r_slot;	// where we read from
     uint32_t	    _w_slot;	// where we write to
     uint32_t        _capacity;
+    uint32_t        _max_burst;
     spinlock_t      _lock;
+    bool	    _debug;
+    bool	    _drop_tail;
+    bool	    _blocking;
     ulong           _read_count;
     ulong           _pkt_read_count;
-    ulong	    _pkt_count;
-    ulong	    _drop_count;
+    ulong           _pkt_count;
+    ulong           _drop_count;
     ulong           _block_count;
-    unsigned	    _max_burst;
     atomic_uint32_t _failed_count;
     Task            _task;
     NotifierSignal  _signal;
     volatile bool   _exit;
     // related to device management
-    String                 _devname;
     ulong                  _dev_major;
     ulong                  _dev_minor;
     wait_queue_head_t      _proc_queue;
     ulong                  _sleep_proc;
+    enum { type_packet, type_stream };
+    uint8_t         _type;
+    enum { type_encap_none, type_encap_pcap, type_encap_len32, type_encap_len_net16 };
+    uint8_t         _encap_type;
+    uint32_t        _pcap_network;
+    uint32_t        _pcap_snaplen;
+    class FromUserDevice *_from_user_device;
 
     static struct file_operations *dev_fops;
+    static volatile ToUserDevice *elem_map[256];
 
     static ssize_t dev_read(struct file *file, char *buf, size_t count, loff_t *ppos);
+    static ssize_t dev_write(struct file *filp, const char *buff, size_t len, loff_t *ppos);
     static int     dev_open(struct inode *inode, struct file *filp);
     static int     dev_release(struct inode *inode, struct file *file);
     static uint    dev_poll(struct file *, struct poll_table_struct *);
-    static int dev_ioctl(struct inode *inode, struct file *filp,
-			 unsigned command, unsigned long address);
+
+    static int write_handler(const String &, Element *e, void *, ErrorHandler *);
+
+    friend class FromUserDevice;
 };
 
 #endif


### PR DESCRIPTION
ToUserDevice is now much more configurable, supporting multiple encapsulation
types (none, pcap, and length-delimited).  It also supports acting like a
datagram socket, where each read corresponds to one packet, or like a streaming
socket, where every byte will definitely be returned, but there is no obvious
cutoff between one packet and the next.

FromUserDevice now depends on an existing ToUserDevice element, and the same
character device is used for both directions of communication.

Here is one example usage of ToUserDevice:

  mknod /dev/click_user0 c 241 0
  cat > /click/config <<EOF
    is :: InfiniteSource(LIMIT 10)
    -> UDPIPEncap(1.1.1.1, 11, 2.2.2.2, 22)
    -> EtherEncap(0x0800, 00:01:02:03:04:05, 00:01:02:03:04:06)
    -> tud :: ToUserDevice(0, ENCAP pcap, BLOCKING false)
  EOF
  cat /dev/click_user0 > /tmp/foo.pcap
  tcpdump -n -r /tmp/foo.pcap

Another would just be to use both ToUserDevice and FromUserDevice to create a
file that could be treated like a UDP socket to communicatie with click (but
without using linux's networking stack).

I believe that I fixed the poll() functions for both elements... but I am not at
all confident that they are really bug-free.

I believe that ToUserDevice has multiple potential bugs involved with unloading
the config and/or removing the click kernel module.  The fact that dev_open
stores a pointer to the element object seems quite unsafe, as if the config is
unloaded, the object would be freed.  Also, the fact that the file_operations
object points to functions in the kernel module means that it is necessary to
make sure that all file handles are closed before unloading the kernel module,
and I don't believe that this is done today.  My gut feeling is that the right
fix for both problems is to actually make cleanup() block until all outstanding
file handles are closed.

Signed-off-by: Cliff Frey cliff@meraki.com
