### PR TITLE
Small notifier fix for pullswitch

### DIFF
--- a/elements/standard/pullswitch.cc
+++ b/elements/standard/pullswitch.cc
@@ -64,9 +64,10 @@ PullSwitch::cleanup(CleanupStage)
 Packet *
 PullSwitch::pull(int)
 {
-    if (_input < 0)
+    if (_input < 0) {
+        _notifier.set_active(false, false);
 	return 0;
-    else if (Packet *p = input(_input).pull()) {
+    } else if (Packet *p = input(_input).pull()) {
 	_notifier.set_active(true, false);
 	return p;
     } else {


### PR DESCRIPTION
If the switch's input is set to -1, it is disabled and should notify
registered signal handlers that they should sleep.
