### PR TITLE
Cache-aware RadixIPLookup.

### DIFF
--- a/elements/ip/radixiplookup.cc
+++ b/elements/ip/radixiplookup.cc
@@ -30,27 +30,27 @@ CLICK_DECLS
 
 class RadixIPLookup::Radix { public:
 
-    static Radix *make_radix(int bitshift, int n);
-    static void free_radix(Radix *r);
+    static Radix *make_radix(int level);
+    static void free_radix(Radix *r, int level);
 
-    int change(uint32_t addr, uint32_t mask, int key, bool set);
+    int change(uint32_t addr, uint32_t mask, int key, bool set, int level);
 
-    static inline int lookup(const Radix *r, int cur, uint32_t addr) {
+
+    static inline int lookup(const Radix *r, int cur, uint32_t addr, int level) {
 	while (r) {
-	    int i1 = (addr >> r->_bitshift) & (r->_n - 1);
-	    const Child &c = r->_children[i1];
+	    int i1 = (addr >> _bitshift[level]) & (_nbuckets[level] - 1);
+	    const Child &c = r->_children[i1];	   
 	    if (c.key)
 		cur = c.key;
 	    r = c.child;
+	    level++;
 	}
 	return cur;
     }
+    
+private:
 
-  private:
 
-    int _bitshift;
-    int _n;
-    int _nchildren;
     struct Child {
 	int key;
 	Radix *child;
@@ -59,27 +59,46 @@ class RadixIPLookup::Radix { public:
     Radix()			{ }
     ~Radix()			{ }
 
-    int &key_for(int i) {
-	assert(i >= 2 && i < _n * 2);
-	if (i >= _n)
-	    return _children[i - _n].key;
+    int & key_for(int i, int level) {
+	int n = _nbuckets[level];
+	assert(i >= 2 && i < n * 2);
+	if (i >= n)
+	    return _children[i - n].key;
 	else {
-	    int *x = reinterpret_cast<int *>(_children + _n);
+	    int *x = reinterpret_cast<int *>(_children + n);
 	    return x[i - 2];
 	}
     }
+       
+    static const int _bitshift [5];
+    static const int _nbuckets [5];
 
     friend class RadixIPLookup;
 
 };
 
+const int RadixIPLookup::Radix::_bitshift [5] = {16, 12, 8, 4, 0};
+
+// The number of buckets each node contains
+// 2^16 at the first level and 2^4 at 4 subsequent levels.
+// (2^16).(2^4)^4 = 2^32.
+const int RadixIPLookup::Radix::_nbuckets [5] = {65536, 16, 16, 16, 16};
+    
+int
+RadixIPLookup::find_lookup_key(IPAddress gw, int32_t port) {
+    for(int i=0; i  < _lookup.size(); i++) {
+	if(_lookup[i].gw == gw  &&
+	   _lookup[i].port == port) 
+	    return (i + 1);
+    }
+    return 0;
+}
+
 RadixIPLookup::Radix*
-RadixIPLookup::Radix::make_radix(int bitshift, int n)
+RadixIPLookup::Radix::make_radix(int level)
 {
+    int n = _nbuckets[level];
     if (Radix* r = (Radix*) new unsigned char[sizeof(Radix) + n * sizeof(Child) + (n - 2) * sizeof(int)]) {
-	r->_bitshift = bitshift;
-	r->_n = n;
-	r->_nchildren = 0;
 	memset(r->_children, 0, n * sizeof(Child) + (n - 2) * sizeof(int));
 	return r;
     } else
@@ -87,55 +106,62 @@ RadixIPLookup::Radix::make_radix(int bitshift, int n)
 }
 
 void
-RadixIPLookup::Radix::free_radix(Radix* r)
+RadixIPLookup::Radix::free_radix(Radix* r, int level)
 {
-    if (r->_nchildren)
-	for (int i = 0; i < r->_n; i++)
-	    if (r->_children[i].child)
-		free_radix(r->_children[i].child);
+    int n = _nbuckets[level];
+    for (int i = 0; i < n; i++)
+	if (r->_children[i].child)
+	    free_radix(r->_children[i].child, level+1);
     delete[] (unsigned char *)r;
 }
 
 int
-RadixIPLookup::Radix::change(uint32_t addr, uint32_t mask, int key, bool set)
+RadixIPLookup::Radix::change(uint32_t addr, uint32_t mask, int key, bool set, int level)
 {
-    int i1 = (addr >> _bitshift) & (_n - 1);
+    int shift = _bitshift[level];
+    int n = _nbuckets[level];
+    int i1 = (addr >> shift) & (n - 1);
 
     // check if change only affects children
-    if (mask & ((1U << _bitshift) - 1)) {
+    if (mask & ((1U << shift) - 1)) {
 	if (!_children[i1].child
-	    && (_children[i1].child = make_radix(_bitshift - 4, 16)))
-	    ++_nchildren;
+	    && (_children[i1].child = make_radix(level + 1))) {
+	    ;
+	}
 	if (_children[i1].child)
-	    return _children[i1].child->change(addr, mask, key, set);
+	    return _children[i1].child->change(addr, mask, key, set, level+1);
 	else
 	    return 0;
     }
 
     // find current key
-    i1 = _n + i1;
-    int nmasked = _n - ((mask >> _bitshift) & (_n - 1));
+    i1 = n + i1;
+    int nmasked = n - ((mask >> shift) & (n - 1));
     for (int x = nmasked; x > 1; x /= 2)
 	i1 /= 2;
-    int replace_key = key_for(i1), prev_key = replace_key;
-    if (prev_key && i1 > 3 && key_for(i1 / 2) == prev_key)
-	prev_key = 0;
+    int replace_key = key_for(i1, level), prev_key = replace_key;
+    if (prev_key && i1 > 3 && key_for(i1 / 2, level) == prev_key)
+     	prev_key = 0;
 
     // replace previous key with current key, if appropriate
     if (!key && i1 > 3)
-	key = key_for(i1 / 2);
+	key = (key_for(i1 / 2, level));
+
     if (prev_key != key && (!prev_key || set)) {
-	for (nmasked = 1; i1 < _n * 2; i1 *= 2, nmasked *= 2)
-	    for (int x = i1; x < i1 + nmasked; ++x)
-		if (key_for(x) == replace_key)
-		    key_for(x) = key;
+	for (nmasked = 1; i1 < n * 2; i1 *= 2, nmasked *= 2)
+	    for (int x = i1; x < i1 + nmasked; ++x) {
+		if (key_for(x, level) == replace_key) {
+		    key_for(x, level) = key;		    		    
+		}
+	    }
+	
     }
     return prev_key;
 }
 
 
 RadixIPLookup::RadixIPLookup()
-    : _vfree(-1), _default_key(0), _radix(Radix::make_radix(24, 256))
+    : _vfree(-1), _default_key(0), _radix(Radix::make_radix(0))
 {
 }
 
@@ -147,8 +173,9 @@ RadixIPLookup::~RadixIPLookup()
 void
 RadixIPLookup::cleanup(CleanupStage)
 {
+    int level = 0;
     _v.clear();
-    Radix::free_radix(_radix);
+    Radix::free_radix(_radix, level);
     _radix = 0;
 }
 
@@ -170,20 +197,32 @@ int
 RadixIPLookup::add_route(const IPRoute &route, bool set, IPRoute *old_route, ErrorHandler *)
 {
     int found = (_vfree < 0 ? _v.size() : _vfree), last_key;
+    int lookup_key = find_lookup_key(route.gw, route.port);
+    if(!lookup_key) 
+	lookup_key = _lookup.size() + 1;
+		    
     if (route.mask) {
 	uint32_t addr = ntohl(route.addr.addr());
 	uint32_t mask = ntohl(route.mask.addr());
-	last_key = _radix->change(addr, mask, found + 1, set);
+	int level = 0;
+	last_key = _radix->change(addr, mask, combine_key(found + 1, lookup_key), set, level);
+	// The key returned by change is the combined key, we need only the _v key.
+	last_key = get_key(last_key);
     } else {
-	last_key = _default_key;
+	last_key = get_key(_default_key);
 	if (!last_key || set)
-	    _default_key = found + 1;
+	    _default_key = combine_key(found + 1, lookup_key);
     }
 
     if (last_key && old_route)
 	*old_route = _v[last_key - 1];
     if (last_key && !set)
 	return -EEXIST;
+
+    if (lookup_key == (_lookup.size() + 1)) {
+	GWPort gw_port = {route.gw, route.port};
+	_lookup.push_back(gw_port);
+    }
 
     if (found == _v.size())
 	_v.push_back(route);
@@ -208,10 +247,11 @@ RadixIPLookup::remove_route(const IPRoute& route, IPRoute* old_route, ErrorHandl
     if (route.mask) {
 	uint32_t addr = ntohl(route.addr.addr());
 	uint32_t mask = ntohl(route.mask.addr());
+	int level = 0;
 	// NB: this will never actually make changes
-	last_key = _radix->change(addr, mask, 0, false);
+	last_key = get_key(_radix->change(addr, mask, 0, false, level));
     } else
-	last_key = _default_key;
+	last_key = get_key(_default_key);
 
     if (last_key && old_route)
 	*old_route = _v[last_key - 1];
@@ -223,7 +263,8 @@ RadixIPLookup::remove_route(const IPRoute& route, IPRoute* old_route, ErrorHandl
     if (route.mask) {
 	uint32_t addr = ntohl(route.addr.addr());
 	uint32_t mask = ntohl(route.mask.addr());
-	(void) _radix->change(addr, mask, 0, true);
+	int level = 0;
+	(void) _radix->change(addr, mask, 0, true, level);
     } else
 	_default_key = 0;
     return 0;
@@ -232,10 +273,12 @@ RadixIPLookup::remove_route(const IPRoute& route, IPRoute* old_route, ErrorHandl
 int
 RadixIPLookup::lookup_route(IPAddress addr, IPAddress &gw) const
 {
-    int key = Radix::lookup(_radix, _default_key, ntohl(addr.addr()));
-    if (key) {
-	gw = _v[key - 1].gw;
-	return _v[key - 1].port;
+    int level = 0;    
+    int key = Radix::lookup(_radix, _default_key, ntohl(addr.addr()), level);
+    int lookup_key = get_lookup_key(key);
+    if (lookup_key) {
+	gw = _lookup[lookup_key - 1].gw;
+	return _lookup[lookup_key - 1].port;
     } else {
 	gw = 0;
 	return -1;


### PR DESCRIPTION
Contains three changes to RadixIPLookup which contribute to better
performance (0.87x original lookup time):

1] Removed derviable fields from the Radix class:
    _n, _nchildren and _bitshift have been removed from the Radix
    class.  _n and _bitshift are now stored in an array indexed by the
    level of the radix node. _nchildren was read only in free_radix()
    to check for existing children. This check has been removed, since
    it is possible to safely free existing children by checking if
    r->children[i].child is not NULL.

2] Changed branching factor to (16, 4, 4, 4, 4) from (8, 4, 4, 4,
   4, 4, 4).  There are 2^16 nodes in level zero followed by 2^4 nodes
   in all subsequent levels.

3] Added a compressed vector (_lookup) for route lookups.  _lookup
   holds unique combinations of (gateway, port) pairs. When a route is
   added to the vector, it is added to _v unconditionally. The route is
   added to _lookup only if its (gateway, port) does not already exist
   in _lookup. The higher order 8 bits of the key index into _lookup,
   the remaining 24 bits index into _v.  _lookup is limited to 256
   entries and _v to 16777216.

Tested for correctness using tests in test/ip.
Benchmarked against the original RadixIPLookup, DirectIPLookup, RangeIPLookup
as well as variants of RadixIPLookup.
Benchmarks are available in the perf direcotry of mvenk/click cache_aware_radixtree.

This is joint work with Rohit Krishna Kumar,
under the supervision of Eddie Kohler.
