### PR TITLE
click lexer: support cpp # lines in element configurations

### DIFF
--- a/test/tools/lexer-08.testie
+++ b/test/tools/lexer-08.testie
@@ -1,0 +1,19 @@
+%info
+Check cpp processor directives
+%script
+
+click A.click
+
+%file A.click
+m :: Message(
+# 100 "foobar.click"
+"test");
+m2 :: Message("test2");
+DriverManager(stop);
+
+%expect -w stdout
+%expect -w stderr
+A.click:1: While configuring 'm :: Message':
+  test
+foobar.click:101: While configuring 'm2 :: Message':
+  test2


### PR DESCRIPTION
This caused issues for Meraki with some elements (like AnnotationInfo) which
would have very large configurations, sometimes with large #ifdef parts.

Signed-off-by: Cliff Frey cliff@meraki.com
