### PR TITLE
arptable: limit arp query rate a bit more

### DIFF
--- a/elements/ethernet/arptable.hh
+++ b/elements/ethernet/arptable.hh
@@ -146,6 +146,7 @@ class ARPTable : public Element { public:
 	ARPEntry *_hashnext;
 	EtherAddress _eth;
 	bool _known;
+	uint8_t _num_polls_since_reply;
 	click_jiffies_t _live_at_j;
 	click_jiffies_t _polled_at_j;
 	Packet *_head;
@@ -165,7 +166,7 @@ class ARPTable : public Element { public:
 	}
 	ARPEntry(IPAddress ip)
 	    : _ip(ip), _hashnext(), _eth(EtherAddress::make_broadcast()),
-	      _known(false), _head(), _tail() {
+	      _known(false), _num_polls_since_reply(0), _head(), _tail() {
 	}
     };
 

--- a/test/ethernet/ARPQuerier-02.testie
+++ b/test/ethernet/ARPQuerier-02.testie
@@ -29,6 +29,6 @@ Idle -> [1]arpq3;
 DriverManager(wait_stop 3, print c.count, print c2.count, print c3.count)
 
 %expect stdout
-{{15|16}}
-{{13|14|15}}
+{{6|7}}
+{{6|7}}
 {{2|3}}


### PR DESCRIPTION
I ran into a case where a syslog server was taken offline.  There was a steady
stream of ~50 UDP messages/second going to this server, and
ARPTable/ARPQuerier's default behavior was to send out 10 broadcast ARP queries
per second in this case.  This was resulting in more broadcast traffic than
really seems necessary.

We now will send out the first 5 arp queries at a rate of 10/sec, and then slow
down to one query per 2 seconds.

Signed-off-by: Cliff Frey cliff@meraki.com
