### PR TITLE
AnyDevice: Ensure non-existent devices are added to the device map

### DIFF
--- a/elements/linuxmodule/anydevice.cc
+++ b/elements/linuxmodule/anydevice.cc
@@ -183,7 +183,12 @@ AnyDevice::lookup_device(ErrorHandler *errh)
 void
 AnyDevice::set_device(net_device *dev, AnyDeviceMap *adm, int flags)
 {
-    if (_dev == dev) {		// no device change == carrier sense only
+     if (!dev && !_dev && !_in_map && adm) {
+	adm->insert(this, flags & anydev_change);
+	return;
+    }
+
+   if (_dev == dev) {		// no device change == carrier sense only
 	bool carrier_ok = (_dev && netif_carrier_ok(_dev));
 	if (carrier_ok != _carrier_ok) {
 	    _carrier_ok = carrier_ok;


### PR DESCRIPTION
The logic rework in ae76f68c1bae0a19adb6f22937f6b2cf4f7911d5
introduced a subtle bug. If a FromDevice/ToDevice/ToHost element
uses ALLOW_NONEXISTENT true, AnyDevice::set_device() would fail
to enter the device into the AnyDeviceMap.

The problem is that set_device() assumes that since _dev == dev
(which will happen in the non-existent case since NULL == NULL)
this is a carrier change only, and it exits early without ever
entering the device in the map.

The previous implementation of AnyDevice::find_device() did not
have this problem, as it would insert the device unconditionally.

Check explicitly for this case (new device being inserted, and it
is a non-existent device, and it is not in the map already), and
add it to the map.

Signed-off-by: Kevin Paul Herbert kph@meraki.net
