### PR TITLE
script: fix append vs. overwrite

### DIFF
--- a/elements/standard/script.cc
+++ b/elements/standard/script.cc
@@ -428,7 +428,7 @@ Script::step(int nsteps, int step_type, int njumps, ErrorHandler *errh)
 	case insn_append: {
 	    String word = cp_shift_spacevec(_args3[ipos]);
 	    String file = (_args3[ipos] ? _args3[ipos] : "-");
-	    _args3[ipos] = (">>" + (insn == insn_save)) + file + " " + word;
+	    _args3[ipos] = String(">>" + (insn == insn_save)) + file + " " + word;
 	    /* FALLTHRU */
 	}
 #endif


### PR DESCRIPTION
The intent of this code is to create a new String, either ">> $file" or ">
$file" depending on whether the instruction is append or overwrite.
However, the string literal is not properly coerced into a String before
being added to another String.
