### PR TITLE
Support atomic_cmpxchg on architectures that define it as a function

### DIFF
--- a/config-linuxmodule.h.in
+++ b/config-linuxmodule.h.in
@@ -43,6 +43,9 @@
 /* Define if your Linux kernel architecture defines atomic_set_mask. */
 #undef HAVE_LINUX_ATOMIC_SET_MASK
 
+/* Define if your Linux kernel architecture defines atomic_cmpxchg */
+#undef HAVE_LINUX_ATOMIC_CMPXCHG
+
 /* Define if your Linux kernel has files_lock. */
 #undef HAVE_LINUX_FILES_LOCK
 

--- a/configure
+++ b/configure
@@ -11858,6 +11858,40 @@ $as_echo "#define HAVE_NETDEV_USES_TRAILER_TAGS 1" >>confdefs.h
 
     fi
 
+    ac_fn_c_check_decl "$LINENO" "atomic_cmpxchg" "ac_cv_have_decl_atomic_cmpxchg" "#if HAVE_LINUXMODULE_2_6
+# define KBUILD_STR(s)		#s
+# define KBUILD_BASENAME	KBUILD_STR(click)
+# define KBUILD_MODNAME		KBUILD_STR(click)
+#endif
+#define new linux_new
+#define this linux_this
+#define delete linux_delete
+#define class linux_class
+#define virtual linux_virtual
+#define typename linux_typename
+#define private linux_private
+#define protected linux_protected
+#define public linux_public
+#define namespace linux_namespace
+#define false linux_false
+#define true linux_true
+#define CLICK_CXX_PROTECTED 1
+$linux_autoconf_include
+#include <asm/types.h>
+#include <asm/atomic.h>
+"
+if test "x$ac_cv_have_decl_atomic_cmpxchg" = xyes; then :
+  ac_cv_linux_atomic_cmpxchg=yes
+else
+  ac_cv_linux_atomic_cmpxchg=no
+fi
+
+    if test $ac_cv_linux_atomic_cmpxchg = yes; then
+
+$as_echo "#define HAVE_LINUX_ATOMIC_CMPXCHG 1" >>confdefs.h
+
+    fi
+
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for netdev_rx_handler_register kernel symbol" >&5
 $as_echo_n "checking for netdev_rx_handler_register kernel symbol... " >&6; }
 if ${ac_cv_linux_netdev_rx_handler_register+:} false; then :

--- a/configure.in
+++ b/configure.in
@@ -1521,6 +1521,12 @@ void f1(int64_t) { // will fail if long long and int64_t are the same type
 	AC_DEFINE([HAVE_NETDEV_USES_TRAILER_TAGS], [1], [Define if you have the netdev_uses_trailer_tags function.])
     fi
 
+    AC_CHECK_DECL(atomic_cmpxchg, [ac_cv_linux_atomic_cmpxchg=yes], [ac_cv_linux_atomic_cmpxchg=no], [CLICK_LINUXMODULE_PROLOGUE()[
+#include <asm/atomic.h>]])
+    if test $ac_cv_linux_atomic_cmpxchg = yes; then
+	AC_DEFINE([HAVE_LINUX_ATOMIC_CMPXCHG], [1], [Define if you have the atomic_cmpxchg function.])
+    fi
+
     AC_CACHE_CHECK(for netdev_rx_handler_register kernel symbol, ac_cv_linux_netdev_rx_handler_register,
     [if grep "__ksymtab_netdev_rx_handler_register" $linux_system_map >/dev/null 2>&1; then
         ac_cv_linux_netdev_rx_handler_register=yes

--- a/include/click/atomic.hh
+++ b/include/click/atomic.hh
@@ -535,7 +535,7 @@ atomic_uint32_t::compare_swap(uint32_t expected, uint32_t desired)
 		  : "r" (desired), "0" (expected), "m" (CLICK_ATOMIC_VAL)
 		  : "cc", "memory");
     return expected;
-#elif CLICK_LINUXMODULE && defined(atomic_cmpxchg)
+#elif CLICK_LINUXMODULE && HAVE_LINUX_ATOMIC_CMPXCHG
     return atomic_cmpxchg(&_val, expected, desired);
 #elif CLICK_LINUXMODULE
 # warning "using nonatomic approximation for atomic_uint32_t::compare_swap"
@@ -579,7 +579,7 @@ atomic_uint32_t::compare_and_swap(uint32_t expected, uint32_t desired)
 		  : "r" (desired), "m" (CLICK_ATOMIC_VAL), "a" (expected)
 		  : "cc", "memory");
     return (uint8_t) expected;
-#elif CLICK_LINUXMODULE && defined(atomic_cmpxchg)
+#elif CLICK_LINUXMODULE && HAVE_LINUX_ATOMIC_CMPXCHG
     return atomic_cmpxchg(&_val, expected, desired) == expected;
 #elif CLICK_LINUXMODULE
 # warning "using nonatomic approximation for atomic_uint32_t::compare_and_swap"


### PR DESCRIPTION
Click uses the C-preprocessor to determine whether an architecture
has defined atomic_cmpxchg. The ARM architecture (among others)
defines this as an inline function, so Click will not attempt
to use atomic_cmpxchg on those architectures. This causes the
warning "using nonatomic approximation..." when building for SMP
on ARM.

Signed-off-by: Kevin Paul Herbert kph@meraki.net
