### PR TITLE
Fix negative MAXLENGTH support in Print

### DIFF
--- a/elements/standard/print.cc
+++ b/elements/standard/print.cc
@@ -45,7 +45,7 @@ Print::configure(Vector<String> &conf, ErrorHandler* errh)
   bool print_anno = false, headroom = false, bcontents;
   _active = true;
   String label, contents = "HEX";
-  unsigned bytes = 24;
+  int bytes = 24;
 
     if (Args(conf, this, errh)
 	.read_p("LABEL", label)


### PR DESCRIPTION
The documented negative length behaviour of Print does not work, as the argument is parsed in an unsigned variable.
testcase: Idle -> Print(MAXLENGTH -1) -> Discard;
(Never thought I would be able to submit a patch for this element :-) )
