### PR TITLE
Json: Fix a bug in (const_)?array_iterator

### DIFF
--- a/elements/json/json.hh
+++ b/elements/json/json.hh
@@ -525,7 +525,7 @@ class Json::const_array_iterator { public:
 	return live() ? &const_array_iterator::live : 0;
     }
     bool live() const {
-	return j_->_type == j_array && JsonVector::size_type(i_) < j_->ajson()->values.size();
+	return j_->_type == j_array && j_->ajson() && JsonVector::size_type(i_) < j_->ajson()->values.size();
     }
     const Json &operator*() const {
 	return j_->ajson()->values[i_];

--- a/elements/test/jsontest.cc
+++ b/elements/test/jsontest.cc
@@ -134,8 +134,13 @@ JsonTest::initialize(ErrorHandler *errh)
     CHECK(j["a"].is_null());
     CHECK(j.count("a") == 1);
 
-    j = Json::make_object();
     Json k = Json::make_array();
+    {
+	CHECK(k.size() == 0);
+	Json::array_iterator it = k.abegin();
+	CHECK(!it.live());
+    }
+    j = Json::make_object();
     j["a"] = k[2];
     CHECK(j.size() == 1);
     CHECK(k.size() == 0);


### PR DESCRIPTION
const_array_iterator::live() was not checking for null _cjson; this was causing
segfaults/kernel panics trying to iterate over an empty, non-uniqueified array.
