### PR TITLE
TX queue locking fix

### DIFF
--- a/elements/linuxmodule/todevice.cc
+++ b/elements/linuxmodule/todevice.cc
@@ -257,7 +257,9 @@ ToDevice::cleanup(CleanupStage stage)
 # define click_netif_tx_queue_frozen(txq)	0
 #endif
 
-#ifdef NETIF_F_LLTX
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 30) && !HAVE_LINUX_POLLING
+# define click_netif_needs_lock(dev)		0 /* dev_queue_xmit() calls HARD_TX_LOCK() */
+#elif defined(NETIF_F_LLTX)
 # define click_netif_needs_lock(dev)		(((dev)->features & NETIF_F_LLTX) == 0)
 #else
 # define click_netif_needs_lock(dev)		1


### PR DESCRIPTION
Locking the TX queue of a network device in Click causes trouble in Linux kernels newer than 2.6.30.

Since commit d65bfe4, the Linux kernel's dev_queue_xmit() function is called from ToDevice::queue_packet() if the kernel version is higher than 2.6.30. It seems that dev_queue_xmit() (in net/core/dev.c) may either call HARD_TX_LOCK() for the queue by itself, or then it may call __dev_xmit_skb() which may call sch_direct_xmit() (in net/sched/sch_generic.c) which calls HARD_TX_LOCK(). Therefore, because the Linux kernel code takes care of locking the queue, that should not be done by Click. And that's what I'm trying to fix here. I've tested that my simple fix works at least in Ubuntu 12.04.1 LTS, kernel version 3.2.0-31 (patchless Click).

Seems that this bug was hiding behind another bug for some time - until commit 5b88803 fixed the interpretation of the NETIF_F_LLTX flag. However, with newer kernels, not locking the TX queue in Click happened to be the right thing to do even for drivers that don't support lockless TX (i.e., most drivers as LLTX is deprecated).
