### PR TITLE
classification.hh: fix bug when matching with an empty program

### DIFF
--- a/elements/standard/classification.hh
+++ b/elements/standard/classification.hh
@@ -357,7 +357,6 @@ inline int
 Program::match(const Packet *p)
 {
     const unsigned char *packet_data = p->data() - _align_offset;
-    Insn *ex = &_insn[0];	// avoid bounds checking
     int pos = 0;
 
     if (_output_everything >= 0)
@@ -366,6 +365,7 @@ Program::match(const Packet *p)
 	// common case never checks packet length
 	return length_checked_match(p);
 
+    Insn *ex = &_insn[0];     // avoid bounds checking
     do {
 	uint32_t data = *((const uint32_t *)(packet_data + ex[pos].offset));
 	data &= ex[pos].mask.u;

--- a/test/standard/Classifier-02.testie
+++ b/test/standard/Classifier-02.testie
@@ -1,0 +1,14 @@
+%info
+Test that an empty Classifier program doesn't crash and does the right thing.
+
+%script
+click --simtime CONFIG 2>OUT 1>&2
+
+%file CONFIG
+InfiniteSource(LIMIT 1, STOP true)
+-> Classifier(-)
+-> Print(A)
+-> Discard;
+
+%expect OUT
+A:{{.*}}


### PR DESCRIPTION
Any Classifier whose first argument is '-' or '0/??' (or similar I guess) aborts
with:
    vector.hh:288: T& Vector<T>::operator[](int) [with T =
    Classification::Wordwise::Insn]: Assertion `(unsigned) i < (unsigned) vm_.n_'
    failed.

Classifier-02.testie demonstrates the bug.

I think what's going on is that the resulting Program is empty for such cases,
but match() nevertheless tries to initialize a variable with the first
instruction in the Program.  This change just moves the variable declaration and
initialisation to where we know the Program isn't empty, namely the point where
match() would have returned on _output_everything >= 0 for an empty Program.

Cliff Frey reviewed this and made a correction to my initial fix.

Signed-off-by: Patrick Verkaik patrick@meraki.net
