### PR TITLE
linuxmodule/todevce: don't attempt to defer packet after dev_queue_xmit

### DIFF
--- a/elements/linuxmodule/todevice.cc
+++ b/elements/linuxmodule/todevice.cc
@@ -503,6 +503,7 @@ ToDevice::queue_packet(Packet *p, struct netdev_queue *txq)
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 30)
     ret = dev_queue_xmit(skb1);
+    p = 0;
 #else
     ret = dev->hard_start_xmit(skb1, dev);
 #endif


### PR DESCRIPTION
After dev_queue_xmit, the packet has been consumed regardless of ret. If ret
were not zero, _q = p despite this fact and it will be Packet::kill'd by
ToDevice::cleanup.  We could skb_clone but that seems wasteful; instead,
drop.

We could also skb_get and then consume_skb on success except that there are
some network drivers (e.g. ppp_generic) that assume the skb it unshared and
will BUG otherwise.
