### PR TITLE
Uninitialized timestamp variable in RandomSource

### DIFF
--- a/elements/standard/randomsource.cc
+++ b/elements/standard/randomsource.cc
@@ -37,7 +37,7 @@ RandomSource::configure(Vector<String> &conf, ErrorHandler *errh)
     counter_t limit = -1;
     int burstsize = 1;
     int datasize = -1;
-    bool active = true, stop = false;
+    bool active = true, stop = false, timestamp = true;
     HandlerCall end_h;
 
     if (Args(conf, this, errh)
@@ -45,6 +45,7 @@ RandomSource::configure(Vector<String> &conf, ErrorHandler *errh)
 	.read_p("LIMIT", limit)
 	.read_p("BURST", burstsize)
 	.read_p("ACTIVE", active)
+	.read("TIMESTAMP", timestamp)
 	.read("STOP", stop)
 	.read("END_CALL", HandlerCallArg(HandlerCall::writable), end_h)
 	.complete() < 0)
@@ -61,6 +62,7 @@ RandomSource::configure(Vector<String> &conf, ErrorHandler *errh)
     _burstsize = burstsize;
     _count = 0;
     _active = active;
+    _timestamp = timestamp;
     delete _end_h;
     if (end_h)
 	_end_h = new HandlerCall(end_h);

--- a/elements/standard/randomsource.hh
+++ b/elements/standard/randomsource.hh
@@ -48,6 +48,11 @@ false.
 A write handler called once LIMIT packets are sent. END_CALL and
 STOP are mutually exclusive.
 
+=item TIMESTAMP
+
+Boolean. If false, do not set the timestamp annotation on generated
+packets. Defaults to true.
+
 =e
 
   RandomSource(64) -> Queue -> ...


### PR DESCRIPTION
Uninitialized variable results in random behaviour on different architectures: once variable is true, what means timestamps are set (what results eg. in lower performance), otherwise variable is false and timestamps are not set
