### PR TITLE
linuxmodule: fix another HandlerStrings issue

### DIFF
--- a/linuxmodule/clickfs.cc
+++ b/linuxmodule/clickfs.cc
@@ -520,6 +520,7 @@ static HandlerString* alloc_handler_string() {
         if (hs)
             handler_strings->push_back(hs);
     }
+    hs->flags = -1;
     SPIN_UNLOCK(&handler_strings_lock, __FILE__, __LINE__);
     return hs;
 }


### PR DESCRIPTION
In the new alloc_handler_string() code, we no longer have access to Handler*
so the caller is responsible to setting HandlerString::flags.

Unfortunately, this member also indicates whether the HS is in-use or not
since in-use and not-in-use HSs exist in the same List.  Since it is the
callers responsibility to set flags to an actual value, it is possible for
one caller to mistakenly take an in-use HandlerString before a previous
caller has written flags.
