### PR TITLE
linuxmodule/clickfs: change read locks to write locks (temporary hack)

### DIFF
--- a/linuxmodule/clickfs.cc
+++ b/linuxmodule/clickfs.cc
@@ -61,8 +61,8 @@ static int clickfs_ready;
 #define SPIN_LOCK(l, file, line)	do { SPIN_LOCK_MSG((l), (file), (line), "lock"); mutex_lock((l)); } while (0)
 #define SPIN_UNLOCK(l, file, line)	do { SPIN_LOCK_MSG((l), (file), (line), "unlock"); mutex_unlock((l)); } while (0)
 
-#define LOCK_CONFIG_READ()	lock_config(__FILE__, __LINE__, 0)
-#define UNLOCK_CONFIG_READ()	unlock_config_read()
+#define LOCK_CONFIG_READ()	lock_config(__FILE__, __LINE__, 1)
+#define UNLOCK_CONFIG_READ()	unlock_config_write(__FILE__, __LINE__)
 #define LOCK_CONFIG_WRITE()	lock_config(__FILE__, __LINE__, 1)
 #define UNLOCK_CONFIG_WRITE()	unlock_config_write(__FILE__, __LINE__)
 


### PR DESCRIPTION
In ClickIno::prepare, we might invoke ClickIno::grow, which potentially
reallocates and moves a shared structure.  This is not safe under a read
lock since other readers might be holding references to objects in the
modified array.  Unfortunately, there are a bunch of places in
linuxmodule/clickfs that invoke ClickIno::prepare under a read lock instead
of a write lock.

This commit is a temporary fix until either ClickIno or linuxmodule/clickfs
can be fixed properly.
