### PR TITLE
add click inputswitch

### DIFF
--- a/click/elements/standard/inputswitch.cc
+++ b/click/elements/standard/inputswitch.cc
@@ -1,0 +1,63 @@
+#include <click/config.h>
+#include "inputswitch.hh"
+#include <click/args.hh>
+#include <click/error.hh>
+CLICK_DECLS
+
+InputSwitch::InputSwitch()
+{
+}
+
+int
+InputSwitch::configure(Vector<String> &conf, ErrorHandler *errh)
+{
+    int input = 0;
+    if (Args(conf, this, errh).read_p("OUTPUT", input).complete() < 0)
+	return -1;
+    if (input >= ninputs())
+	return errh->error("input must be < %d", ninputs());
+    _input = input;
+    return 0;
+}
+
+void
+InputSwitch::push(int port, Packet *p)
+{
+    if (port == _input)
+	output(0).push(p);
+    else
+	p->kill();
+}
+
+String
+InputSwitch::read_param(Element *e, void *)
+{
+    InputSwitch *sw = (InputSwitch *)e;
+    return String(sw->_input);
+}
+
+int
+InputSwitch::write_param(const String &s, Element *e, void *, ErrorHandler *errh)
+{
+    InputSwitch *sw = (InputSwitch *)e;
+    int sw_input;
+    if (!IntArg().parse(s, sw_input))
+	return errh->error("InputSwitch input must be integer");
+    if (sw_input >= sw->ninputs())
+	sw_input = -1;
+    sw->_input = sw_input;
+    return 0;
+}
+
+void
+InputSwitch::add_handlers()
+{
+    add_read_handler("switch", read_param, 0);
+    add_write_handler("switch", write_param, 0, Handler::NONEXCLUSIVE);
+    add_read_handler("config", read_param, 0);
+    set_handler_flags("config", 0, Handler::CALM);
+}
+
+CLICK_ENDDECLS
+EXPORT_ELEMENT(InputSwitch)
+ELEMENT_MT_SAFE(InputSwitch)

--- a/click/elements/standard/inputswitch.hh
+++ b/click/elements/standard/inputswitch.hh
@@ -1,0 +1,51 @@
+#ifndef CLICK_INPUTSWITCH_HH
+#define CLICK_INPUTSWITCH_HH
+#include <click/element.hh>
+CLICK_DECLS
+
+/*
+=c
+
+InputSwitch([INPUT])
+
+=s classification
+
+accepts packet stream from settable input
+
+=d
+
+InputSwitch only accepts incoming packet on one of its input ports --
+specifically, INPUT. The default INPUT is zero; negative INPUT means to
+destroy input packets instead of forwarding them. You can change INPUT with a
+write handler. InputSwitch has an unlimited number of inputs.
+
+=h switch read/write
+
+Return or set the INPUT parameter.
+
+=a Switch, PullSwitch */
+
+class InputSwitch : public Element { public:
+
+    InputSwitch() CLICK_COLD;
+
+    const char *class_name() const		{ return "InputSwitch"; }
+    const char *port_count() const		{ return "-/1"; }
+    const char *processing() const		{ return PUSH; }
+    void add_handlers() CLICK_COLD;
+
+    int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
+    bool can_live_reconfigure() const		{ return true; }
+
+    void push(int, Packet *);
+
+ private:
+
+    int _input;
+
+    static String read_param(Element *, void *) CLICK_COLD;
+    static int write_param(const String &, Element *, void *, ErrorHandler *) CLICK_COLD;
+};
+
+CLICK_ENDDECLS
+#endif


### PR DESCRIPTION
InputSwitch is like Switch, except it selects an input port rather than
an output port. Unlike PullSwitch, InputSwitch uses push processing.

For example, for a wireless roaming client you can now say:
    ap0, ap1, ap2
    => cli_in_sw :: InputSwitch(0)
    -> cli
    -> cli_out_sw :: Switch(0)
    => ap0, ap1, ap2;

and then:
    write cli_in_sw.switch 1,
    write cli_out_sw.switch 1,
to make it roam to ap1.

Reviewed-by: cliff@meraki.com
Signed-off-by: Patrick Verkaik patrick@meraki.net
