### PR TITLE
linuxmodule/FromHost: add ether handler

### DIFF
--- a/elements/linuxmodule/fromhost.hh
+++ b/elements/linuxmodule/fromhost.hh
@@ -191,7 +191,7 @@ class FromHost : public AnyDevice, public Storage { public:
     static net_device_stats *fl_stats(net_device *dev);
 #endif
 
-    enum { h_length, h_burst };
+    enum { h_length, h_burst, h_ether };
     static String read_handler(Element *e, void *thunk) CLICK_COLD;
     static int write_handler(const String &, Element *, void *, ErrorHandler *) CLICK_COLD;
 };


### PR DESCRIPTION
Previously, one would need to

```
ifconfig dev down
ifconfig dev hw ether 01:02:03:04:05:06
ifconfig dev up
```

in order to change the MAC address of a FromDevice.  This commit adds a
handler that does all of this automatically, which means you can change the
MAC from a Script.

This is useful if you have a FromHost/ToHost that are hooked up to a
ToDevice/FromDevice and you want the MACs to match.  If the actual interface
might not actually be available at click initialization time, this handler
make it possible to adjust the FromHost once the FromDevice is attached.
