### PR TITLE
TCPRewriter: add perform_mapping handler

### DIFF
--- a/elements/tcpudp/tcprewriter.hh
+++ b/elements/tcpudp/tcprewriter.hh
@@ -80,6 +80,15 @@ packets to the rewritten destination address. Default is true.
 Returns a human-readable description of the TCPRewriter's current mapping
 table.
 
+=h lookup
+
+Takes a flow as a space-separated
+
+    saddr sport daddr dport
+
+and attempts to find a forward mapping for that flow. If found, rewrites the
+flow and returns in the same format.  Otherwise, returns nothing.
+
 =a IPRewriter, IPAddrRewriter, IPAddrPairRewriter, IPRewriterPatterns,
 FTPPortMapper */
 
@@ -181,6 +190,7 @@ class TCPRewriter : public IPRewriterBase { public:
     }
 
     static String tcp_mappings_handler(Element *, void *);
+    static int tcp_lookup_handler(int, String &str, Element *e, const Handler *h, ErrorHandler *errh);
 
 };
 

--- a/test/IPRewriter/IPRewriter-10.testie
+++ b/test/IPRewriter/IPRewriter-10.testie
@@ -1,5 +1,5 @@
 %info
-Pattern reconfiguration and mapping unparsing.
+Pattern reconfiguration, mapping unparsing, and mapping lookup.
 
 %script
 
@@ -18,7 +18,17 @@ ps[3] -> Counter(COUNT_CALL 1 s.run) -> Idle
 s :: Script(TYPE PASSIVE,
   write rw1.pattern0 pattern 1.0.0.4 1024-65534# - - 0 1,
   print rw1.patterns)
-DriverManager(pause, print >M rw1.tcp_table, stop)
+DriverManager(pause,
+	print >M rw1.tcp_table,
+	print >RM rw1.lookup 1.0.0.2 1024 1.0.0.3 1025,
+	print >>RM rw1.lookup 2.115.2.2 2 1.0.0.2 1024,
+	print >>RM rw1.lookup 2.115.2.2 2 1.0.0.3 1024,
+	print >>RM rw1.lookup 2.115.2.2 2 1.0.0.4 1024,
+	print >>RM rw1.lookup 2.115.2.2 2 1.0.0.4 1025,
+	print >>RM rw1.lookup 53.1.1.1 1 2.115.2.2 2,
+	print >>RM rw1.lookup 53.1.1.2 1 2.115.2.2 2,
+	print >>RM rw1.lookup 53.1.1.4 1 2.115.2.2 2,
+	stop)
 "
 
 sort M
@@ -73,6 +83,16 @@ sort M
 (53.1.1.1, 1, 2.115.2.2, 2) => (1.0.0.4, 1024, 2.115.2.2, 2) [*0 1] i0{{.*}}
 (53.1.1.2, 1, 2.115.2.2, 2) => (1.0.0.3, 1024, 2.115.2.2, 2) [*0 1] i1{{.*}}
 (53.1.1.4, 1, 2.115.2.2, 2) => (1.0.0.4, 1025, 2.115.2.2, 2) [*0 1] i0{{.*}}
+
+%expect RM
+1.0.0.2 1024 2.115.2.2 2
+1.0.0.3 1025 1.0.0.2 1024
+2.115.2.2 2 53.1.1.2 1
+2.115.2.2 2 53.1.1.1 1
+2.115.2.2 2 53.1.1.4 1
+1.0.0.4 1024 2.115.2.2 2
+1.0.0.3 1024 2.115.2.2 2
+1.0.0.4 1025 2.115.2.2 2
 
 %ignorex OUT1
 ^!.*


### PR DESCRIPTION
This handler takes in a flow as a space-separated

```
saddr sport daddr dport
```

and looks for a forward mapping for that flow.  If found, it returns the rewritten flow in the same format. I went with this format for ease of parsing in userland.

This is useful when using a TCPRewriter to divert traffic to a proxy in userland.  It allows the proxy to figure out the original destination for the flow, similar to SO_ORIGINAL_DST for Netfilter or SIOCGNATL for IP-Filter.
