### PR TITLE
stridesched: fix initialize

### DIFF
--- a/elements/standard/stridesched.cc
+++ b/elements/standard/stridesched.cc
@@ -69,7 +69,7 @@ StrideSched::configure(Vector<String> &conf, ErrorHandler *errh)
 int
 StrideSched::initialize(ErrorHandler *)
 {
-    if (input_is_push(0))
+    if (input_is_pull(0))
 	for (int i = 0; i < nclients(); ++i)
 	    _all[i]._signal = Notifier::upstream_empty_signal(this, i);
     return 0;


### PR DESCRIPTION
This was preventing the signal/notifier optimization path from working
for StrideSched.  The conditional is here because this code is shared by
StrideSwitch.

Signed-off-by: Cliff Frey cliff@meraki.com
