### PR TITLE
nsclick: Correct offset when parsing serialized defines.

### DIFF
--- a/ns/nsclick.cc
+++ b/ns/nsclick.cc
@@ -135,7 +135,7 @@ int simclick_click_create(simclick_node_t *simnode, const char* router_file) {
         while (defines_offset < defines_size) {
             char *key = defines + defines_offset;
             char *value = key + strlen(key) + 1;
-            defines_offset += (size_t) (value + strlen(value) + 1 - defines);
+            defines_offset = (size_t) (value + strlen(value) + 1 - defines);
             if (!click_lexer()->global_scope().define(key, value, false)) {
                 errh->error("parameter %s multiply defined", key);
             }


### PR DESCRIPTION
Hey,

i finally managed to do a fork of click on github. Now it should be a lot easier to provide patches for click.

This patch is required fixing a bug in parsing variable definitions from ns3. Without this patch, only the first variable is parsed correctly. I already sent you this patch on 25.04.2013 via the click mailing list, but it seems the patch didn't make it into master until now.
