### PR TITLE
RecycledSkbPool: force lock to relax

### DIFF
--- a/linuxmodule/skbmgr.cc
+++ b/linuxmodule/skbmgr.cc
@@ -74,7 +74,7 @@ class RecycledSkbPool { public:
  private:
 
   RecycledSkbBucket _buckets[NBUCKETS];
-  volatile unsigned long _lock;
+  unsigned long _lock;
 #if __MTCLICK__
   int _last_producer;
   atomic_uint32_t _consumers;


### PR DESCRIPTION
Like the commit says, it might be worth just making this a Spinlock but I didn't really look to see if there were any caveats re: that. In the mean time, getting rid of a volatile and maybe letting the CPU relax a bit is a good start.
