### PR TITLE
args: fix read_all() uninitialized warning

### DIFF
--- a/include/click/args.hh
+++ b/include/click/args.hh
@@ -811,8 +811,9 @@ class Args : public ArgContext {
 	Vector<T> *s = slot(variable);
 	while (String str = find(keyword, flags, slot_status)) {
 	    T sx;
-	    postparse(parser.parse(str, sx, *this), slot_status);
-	    if (_read_status)
+	    bool ok = parser.parse(str, sx, *this);
+	    postparse(ok, slot_status);
+	    if (ok && _read_status)
 		s->push_back(sx);
 	    read_status = (read_status != 0) && _read_status;
 	    flags &= ~mandatory;


### PR DESCRIPTION
read_all() on IntArg() gives:
.../include/click/args.hh: In function ‘void args_base_read_all(Args_, const char_, int, P, Vector<T>&) [with P = IntArg, T = short unsigned int]’:
.../include/click/args.hh:815:8: warning: ‘sx’ may be used uninitialized in this function [-Wuninitialized]

..the problem being that the compiler doesn't realize postparse() guarantees
that: _read_status => sx initialized.

Reviewed-by: rtshanks@meraki.com
Signed-off-by: Patrick Verkaik patrick@meraki.net
