### PR TITLE
Netmap API 10+ support

### DIFF
--- a/elements/userlevel/netmapinfo.cc
+++ b/elements/userlevel/netmapinfo.cc
@@ -115,7 +115,9 @@ NetmapInfo::ring::close(int fd)
 	netmap_memory = MAP_FAILED;
     }
     netmap_memory_lock.release();
+#if NETMAP_API < 10
     ioctl(fd, NIOCUNREGIF, (struct nmreq *) 0);
+#endif
     ::close(fd);
 }
 

--- a/elements/userlevel/netmapinfo.hh
+++ b/elements/userlevel/netmapinfo.hh
@@ -8,6 +8,16 @@
 #include <click/error.hh>
 CLICK_DECLS
 
+#if NETMAP_API > 9
+	#define NETMAP_RING_FIRST_RESERVED(r)                   \
+		((r)->head)
+	#define NETMAP_RING_NEXT nm_ring_next
+#else
+	static inline int nm_ring_space(struct netmap_ring* ring) {
+		return ring->avail;
+	}
+#endif
+
 class NetmapInfo { public:
 
     struct ring {
@@ -38,11 +48,67 @@ class NetmapInfo { public:
 	    unsigned res1idx = NETMAP_RING_FIRST_RESERVED(ring);
 	    ring->slot[res1idx].buf_idx = NETMAP_BUF_IDX(ring, (char *) buf);
 	    ring->slot[res1idx].flags |= NS_BUF_CHANGED;
+	#if NETMAP_API < 10
 	    --ring->reserved;
+	#else
+	    ring->head++;
+	    if (ring->head == ring->num_slots) ring->head = 0;
+	#endif
 	    return true;
 	} else
 	    return false;
     }
+
+    static inline int nm_ring_reserved(struct netmap_ring *ring) {
+	#if NETMAP_API < 10
+    	return ring->reserved;
+	#else
+    	int ret = ring->cur - ring->head;
+    	if (ret < 0)
+    		ret += ring->num_slots;
+    	return ret;
+	#endif
+    }
+
+    static inline bool nm_ring_has_avail(struct netmap_ring *ring) {
+	#if NETMAP_API < 10
+    	return ring->avail > 0;
+	#else
+    	return ring->tail != ring->cur;
+	#endif
+    }
+
+    static inline int nm_advance(struct netmap_ring *ring,int nzcopy) {
+    	ring->cur = NETMAP_RING_NEXT(ring, ring->cur);
+	#if NETMAP_API < 10
+    	--ring->avail;
+    	if (nzcopy > 0) {
+    		++ring->reserved;
+    		return nzcopy - 1;
+    	} else {
+    		return 0;
+    	}
+
+	#else
+    	if (nzcopy > 0) {
+    		return nzcopy - 1;
+    	} else {
+    		ring->head++;
+    		if (ring->head == ring->num_slots) ring->head = 0;
+    		return 0;
+    	}
+	#endif
+    }
+
+    static inline void nm_send_pkt(struct netmap_ring *ring) {
+    	ring->cur = NETMAP_RING_NEXT(ring, ring->cur);
+	#if NETMAP_API < 10
+    	--ring->avail;
+	#else
+    	ring->head = ring->cur;
+	#endif
+    }
+
 
 };
 


### PR DESCRIPTION
Simply adding support for the last version of Netmap, which is API 11. It's been merged in FreeBSD and the Netmap repository for some time now. I used defines to avoid dropping support for old Netmap, but I didn't really tested the code with the "old" Netmap. So the support "should" have been kept...
