### PR TITLE
click: Fix issue with IPFilter processing Ethernet addresses

### DIFF
--- a/elements/ip/ipfilter.cc
+++ b/elements/ip/ipfilter.cc
@@ -724,6 +724,7 @@ IPFilter::Primitive::compile(Classification::Wordwise::Program &p, Vector<int> &
       p.start_subtree(tree);
       Primitive copy(*this);
       if (_srcdst == SD_SRC || _srcdst == SD_AND || _srcdst == SD_OR) {
+          p.start_subtree(tree);
 	  memcpy(copy._u.c, _u.c, 4);
 	  memcpy(copy._mask.c, _mask.c, 4);
 	  copy.add_comparison_exprs(p, tree, offset_mac + 8, 0, true, false);
@@ -731,8 +732,10 @@ IPFilter::Primitive::compile(Classification::Wordwise::Program &p, Vector<int> &
 	  memcpy(copy._u.c, _u.c + 4, 2);
 	  memcpy(copy._mask.c, _mask.c + 4, 2);
 	  copy.add_comparison_exprs(p, tree, offset_mac + 12, 0, true, false);
+          p.finish_subtree(tree, Classification::c_and);
       }
       if (_srcdst == SD_DST || _srcdst == SD_AND || _srcdst == SD_OR) {
+          p.start_subtree(tree);
 	  copy._u.u = copy._mask.u = 0;
 	  memcpy(copy._u.c + 2, _u.c, 2);
 	  memcpy(copy._mask.c + 2, _mask.c, 2);
@@ -740,6 +743,7 @@ IPFilter::Primitive::compile(Classification::Wordwise::Program &p, Vector<int> &
 	  memcpy(copy._u.c, _u.c + 2, 4);
 	  memcpy(copy._mask.c, _mask.c + 2, 4);
 	  copy.add_comparison_exprs(p, tree, offset_mac + 4, 0, true, false);
+          p.finish_subtree(tree, Classification::c_and);
       }
       goto finish_srcdst;
   }

--- a/test/ip/IPFilter-06.testie
+++ b/test/ip/IPFilter-06.testie
@@ -10,6 +10,7 @@ i :: Idle
 -> c :: IPFilter(allow src 0:1:2:3:4:5,
 		 allow src 10.0.0.0 & 8.0.0.0 = 8.0.0.0,
 		 allow dst 10:20:30:40:50:60,
+		 allow host 9:A:B:C:D:E,
 		 deny all)
 -> i;
 
@@ -17,7 +18,11 @@ i :: Idle
  0   8/00010203%ffffffff  yes->step 1  no->step 2
  1  12/04050000%ffff0000  yes->[0]  no->step 2
  2 268/0a000000%ffffffff  yes->[0]  no->step 3
- 3   0/00001020%0000ffff  yes->step 4  no->[X]
- 4   4/30405060%ffffffff  yes->[0]  no->[X]
+ 3   0/00001020%0000ffff  yes->step 4  no->step 5
+ 4   4/30405060%ffffffff  yes->[0]  no->step 5
+ 5   8/090a0b0c%ffffffff  yes->step 6  no->step 7
+ 6  12/0d0e0000%ffff0000  yes->[0]  no->step 7
+ 7   0/0000090a%0000ffff  yes->step 8  no->[X]
+ 8   4/0b0c0d0e%ffffffff  yes->[0]  no->[X]
 safe length 272
 alignment offset 0


### PR DESCRIPTION
An IPFilter expression which scans for a MAC address in either the src
or dst part of the frame, e.g. 'ether host <MAC>' or 'ether src or dst
<MAC>' could emit false positives. The underlying IPFilter driver
breaks down an individual MAC address into 2 chunks of 4 and 2 bytes
respectively. The driver should normally test each chunk against the
incoming address and logically AND the result.  However, in the bug
case, all chunks end up being logically ORed thus only part of the MAC
address needs to match to pass. This submission corrects this by
wrapping each MAC test in a separate subtree that is logically AND'ed
for each src and dst MAC address and then the two results logically
ORed

Also updated the associated click testie to cover this condition.
