### PR TITLE
Add filtering by protocol to FromDevice.

### DIFF
--- a/elements/userlevel/fromdevice.hh
+++ b/elements/userlevel/fromdevice.hh
@@ -251,6 +251,7 @@ class FromDevice : public Element { public:
     bool _timestamp : 1;
     int _was_promisc : 2;
     int _snaplen;
+    uint16_t _protocol;
     unsigned _headroom;
     enum { method_default, method_netmap, method_pcap, method_linux };
     int _method;


### PR DESCRIPTION
Hi Eddie,
i'm using AX.25 devices with click. However, when using FromDevice, i receive two identical frames within click for every frame received by the AX.25 device. This is not a fault of click. I can reproduce the behaviour outside of click, including with wireshark. It turns out that one frame is delivered with a link layer protocol of AX.25 and one with IP. I'm not sure if this is a bug in the AX.25 device driver or if it is a valid behaviour. Anyway, the problem can be solved by filtering the incoming packets by protocol.

Maybe you want to include this patch into mainline.

Regards,
Sascha
