### PR TITLE
Comply with radiotap.org alignment rules

### DIFF
--- a/elements/wifi/radiotapdecap.cc
+++ b/elements/wifi/radiotapdecap.cc
@@ -73,6 +73,9 @@ static int rt_check_header(struct ieee80211_radiotap_header *th, int len, u_int8
 
 	for (x = 0; x < NUM_RADIOTAP_ELEMENTS; x++) {
 		if (rt_el_present(th, x)) {
+		    int pad = bytes % radiotap_elem_to_bytes[x];
+		    if (pad)
+			bytes += radiotap_elem_to_bytes[x] - pad;
 		    offsets[x] = ptr + bytes;
 		    bytes += radiotap_elem_to_bytes[x];
 		}


### PR DESCRIPTION
According to radiotap.org, the header fields have to be aligned according to size, not just tightly packed. This has effecty when reading eg.: TX_FLAGS that is a 16-bit field.
