### PR TITLE
linuxmodule: to device: update queue expiry time when queuing after a drop

### DIFF
--- a/elements/linuxmodule/todevice.cc
+++ b/elements/linuxmodule/todevice.cc
@@ -364,6 +364,7 @@ ToDevice::run_task(Task *)
 	    if (!tx_trylock(dev, txq)) {
 	        _task.reschedule();
 	        _q = p;
+	        _q_expiry_j = click_jiffies() + queue_timeout;
 	        goto bail;
             }
         }


### PR DESCRIPTION
Without this change, any packet queued in this code path is guaranteed
to be dropped, since it has the same expiration time as the packet that
was just dropped.
