### PR TITLE
lib/string: clear dangling pointer on String::deref

### DIFF
--- a/include/click/string.hh
+++ b/include/click/string.hh
@@ -268,8 +268,12 @@ class String { public:
     }
 
     inline void deref() const {
-	if (_r.memo && atomic_uint32_t::dec_and_test(_r.memo->refcount))
-	    delete_memo(_r.memo);
+	if (_r.memo) {
+	    assert(_r.memo->refcount);
+	    if (atomic_uint32_t::dec_and_test(_r.memo->refcount))
+		delete_memo(_r.memo);
+	    _r.memo = 0;
+	}
     }
 
     void assign(const char *s, int len, bool need_deref);

--- a/lib/string.cc
+++ b/lib/string.cc
@@ -129,6 +129,7 @@ String::create_memo(char *space, int dirty, int capacity)
 void
 String::delete_memo(memo_t *memo)
 {
+    assert(!memo->refcount);
     assert(memo->capacity > 0);
     assert(memo->capacity >= memo->dirty);
 #if HAVE_STRING_PROFILING


### PR DESCRIPTION
In order to make use-after-free of Strings fail more quickly, this change
blows away _r.memo on String::deref(), since we should no longer hold a
reference to it.  Additionally, it asserts that the memo_t's refcount is not
zero when deref is invoked, since the caller should have a valid reference
at that point, and also that the refcount is zero when the memo_t is
deleted.
