### PR TITLE
linuxmodule/FromDevice: replace assert with skb_share_check

### DIFF
--- a/elements/linuxmodule/fromdevice.cc
+++ b/elements/linuxmodule/fromdevice.cc
@@ -387,7 +387,10 @@ FromDevice::got_skb(struct sk_buff *skb)
     unsigned next = next_i(_tail), head = _head;
 
     if (next != head) { /* ours */
-	assert(skb_shared(skb) == 0); /* else skb = skb_clone(skb, GFP_ATOMIC); */
+	skb = skb_share_check(skb, GFP_ATOMIC);
+	if (!skb)
+	    return 1;
+	assert(skb_shared(skb) == 0);
 
 	/* Retrieve the MAC header. */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24)


### PR DESCRIPTION
It isn't clear that this assertion holds in general, so just Do the Right
Thing instead.  If the check returns NULL, the original SKB has already lost
a ref, so report that it was handled.
