### PR TITLE
CoDel AQM implementation

### DIFF
--- a/elements/aqm/codel.cc
+++ b/elements/aqm/codel.cc
@@ -1,0 +1,290 @@
+/*
+ * codel.{cc,hh} -- element implements CoDel dropping policy
+ * Apurv Bhartia
+ *
+ * Copyright (c) 2014 Cisco Systems, Inc.
+ */
+
+#include <click/config.h>
+#include "codel.hh"
+#include <click/standard/storage.hh>
+#include <click/routervisitor.hh>
+#include <click/error.hh>
+#include <click/router.hh>
+#include <click/args.hh>
+#include <click/straccum.hh>
+CLICK_DECLS
+
+#define CODEL_DEBUG 0
+
+CoDel::CoDel()
+{
+}
+
+CoDel::~CoDel()
+{
+}
+
+int
+CoDel::finish_configure(const String &queues_string, ErrorHandler *errh)
+{
+    // check queues_string, but only if queues have not been configured already
+    if (queues_string && !_queue_elements.size()) {
+	Vector<String> eids;
+	cp_spacevec(queues_string, eids);
+	_queue_elements.clear();
+	for (int i = 0; i < eids.size(); i++)
+	    if (Element *e = router()->find(eids[i], this, errh))
+		_queue_elements.push_back(e);
+	if (eids.size() != _queue_elements.size())
+	    return -1;
+    }
+
+    return 0;
+}
+
+int
+CoDel::configure(Vector<String> &conf, ErrorHandler *errh)
+{
+    // initialize the target and interval with CoDel-recommended values (5 and 100ms respectively)
+    _codel_target_ts = Timestamp::make_msec(0, 5);
+    _codel_interval_ts = Timestamp::make_msec(0, 100);
+
+    String queues_string = String();
+    if (Args(conf, this, errh)
+    .read_p("TARGET", _codel_target_ts)
+    .read_p("INTERVAL", _codel_interval_ts)
+	.read("QUEUES", AnyArg(), queues_string)
+	.complete() < 0)
+        return -1;
+
+    return finish_configure(queues_string, errh);
+}
+
+int
+CoDel::initialize(ErrorHandler *errh)
+{
+    // Find the next queues upstream
+    _queues.clear();
+    _queue1 = 0;
+
+    if (_queue_elements.empty()) {
+	ElementCastTracker filter(router(), "Storage");
+	int ok = router()->visit_upstream(this, 0, &filter);
+	if (ok < 0)
+	    return errh->error("flow-based router context failure");
+	_queue_elements = filter.elements();
+    }
+
+    if (_queue_elements.empty())
+	return errh->error("no nearby Queues");
+    for (int i = 0; i < _queue_elements.size(); i++)
+	if (Storage *s = (Storage *)_queue_elements[i]->cast("Storage"))
+	    _queues.push_back(s);
+	else
+	    errh->error("%<%s%> is not a Storage element", _queue_elements[i]->name().c_str());
+    if (_queues.size() != _queue_elements.size())
+	return -1;
+    else if (_queues.size() == 1)
+	_queue1 = _queues[0];
+
+    _total_drops = 0;
+    _state_drops = 0;
+    _dropping = false;
+
+    _first_above_time = Timestamp();
+    _drop_next = Timestamp();
+
+    return 0;
+}
+
+int
+CoDel::queue_size() const
+{
+    if (_queue1)
+	return _queue1->size();
+    else {
+	int s = 0;
+	for (int i = 0; i < _queues.size(); i++)
+	    s += _queues[i]->size();
+	return s;
+    }
+}
+
+inline void
+CoDel::handle_drop(Packet *p)
+{
+    if (noutputs() == 1)
+        p->kill();
+    _total_drops++;
+}
+
+// delegate to the codel handler on a pull-request which can then generate (or not) the packet //
+Packet *
+CoDel::pull(int)
+{
+    Packet *pkt = delegate_codel();
+
+    // set the queue delay in the packet for stats later
+    if(pkt != NULL) {
+        SET_FIRST_TIMESTAMP_ANNO(pkt, (Timestamp::now() - FIRST_TIMESTAMP_ANNO(pkt)));
+    }
+    return pkt;
+}
+
+// helper: pull a packet, and tracks if the sojourn time of the packet is above the target //
+Packet *
+CoDel::dequeue_and_track_sojourn_time(Timestamp now, bool &retVal)
+{
+    _ok_to_drop = 0;
+    Packet *p = input(0).pull();
+
+    if (p == NULL) {
+        // if no packet then reset _first_above_time
+        _first_above_time.assign(0, 0);
+        retVal = false;
+        return NULL;
+    } else if (!FIRST_TIMESTAMP_ANNO(p).sec()) {
+        // if FIRST_TIMESTAMP_ANNO not set, then do nothing; imp else CoDel would misbehave!
+        retVal = false;
+        return p;
+    } else {
+        Timestamp sojourn_time = now - FIRST_TIMESTAMP_ANNO(p);
+
+#if CODEL_DEBUG
+        click_chatter("[%d] [%s] sojourn_time: %s pkt_ts: %s target: %s", EXTRA_PACKETS_ANNO(p), now.unparse().c_str(), sojourn_time.unparse().c_str(), FIRST_TIMESTAMP_ANNO(p).unparse().c_str(), _codel_target_ts.unparse().c_str());
+#endif
+
+        if (sojourn_time < _codel_target_ts) {
+            // sojourn_time not high enough, reset again
+            _first_above_time.assign(0, 0);
+        } else {
+            // check if the packet needs to be dropped
+            if (_first_above_time == Timestamp::make_msec(0, 0)) {
+                // first time above sojourn time, then check again later
+                _first_above_time = now + _codel_interval_ts;
+            } else if (now >= _first_above_time) {
+                // mark to drop it
+                _ok_to_drop = 1;
+            }
+        }
+    }
+    retVal = true;
+    return p;
+}
+
+// heavy-lifter - calls dequeue_and_track_sojourn_time and drops packets, if required //
+Packet*
+CoDel::delegate_codel()
+{
+    Packet *p = NULL;
+    bool ret_val = false;
+    Timestamp now = Timestamp::now();
+
+    p = dequeue_and_track_sojourn_time(now, ret_val);
+
+    // ret_val can be false in two cases:
+    //  1. no packet in the queue to pull from
+    //  2. FIRST_TIMESTAMP_ANNO not set in the packet - so 'sojourn_time' cannot be calculated'
+    //  In either case, just return and do nothing
+
+    if (!ret_val) {
+        _dropping = false;
+        return p;
+    }
+
+    // already in the dropping state
+    if (_dropping) {
+        // is it time to leave the dropping state?
+        if (!_ok_to_drop) {
+            _dropping = false;
+        } else if (now >= _drop_next) {
+            // drop the current packet and dequeue the next
+            while ((now >= _drop_next) && _dropping) {
+                assert(now >= _drop_next);
+                handle_drop(p);
+#if CODEL_DEBUG
+                click_chatter("total_drops: %d, now: %s, drop_next: %s\n", _total_drops, now.unparse().c_str(), _drop_next.unparse().c_str());
+#endif
+                ++_state_drops;
+                p = dequeue_and_track_sojourn_time(now, ret_val);
+
+                if (!_ok_to_drop) {
+                    _dropping = false;
+                } else {
+                    _drop_next = control_law(_drop_next);
+                }
+            }
+        }
+    } else if (_ok_to_drop && ((now - _drop_next < _codel_interval_ts) || (now - _first_above_time >= _codel_interval_ts))) {
+
+        // not in the dropping state - want to enter? then check:
+        // 1. been in the 'dropping' state recently, or
+        // 2. first_above_time been above 'interval'
+
+        // drop the packet, dequeue next packet and enter dropping state
+        handle_drop(p);
+        p = dequeue_and_track_sojourn_time(now, ret_val);
+        _dropping = true;
+
+        if (now - _drop_next < _codel_interval_ts) {
+            _state_drops = (_state_drops > 2) ? (_state_drops - 2) : 1;
+        } else {
+            _state_drops = 1;
+        }
+        _drop_next = control_law(now);
+    }
+    return p;
+}
+
+// determines the next drop time of the packet - scaling done to allow usage of int_sqrt to minimize floating point arithmetic, etc. //
+Timestamp
+CoDel::control_law(Timestamp t)
+{
+    uint32_t val_click_ns = (_codel_interval_ts.msecval() * Timestamp::nsec_per_msec << 4)/(int_sqrt((uint32_t) _state_drops << 8));
+    uint32_t val_click_sec = val_click_ns / (Timestamp::nsec_per_sec);
+    uint32_t rem_ns = val_click_ns % (Timestamp::nsec_per_sec);
+    Timestamp val_click_ts = Timestamp::make_nsec(val_click_sec, rem_ns);
+    return (t + val_click_ts);
+}
+
+// HANDLERS
+
+String
+CoDel::read_handler(Element *f, void *vparam)
+{
+    CoDel *codel = (CoDel *)f;
+    StringAccum sa;
+    switch ((intptr_t)vparam) {
+        case 2:     // stats //
+            sa << codel->queue_size() << " current queue\n"
+               << codel->drops() << " drops\n";
+            return sa.take_string();
+
+        case 3:	    // queues //
+            for (int i = 0; i < codel->_queue_elements.size(); i++)
+                sa << codel->_queue_elements[i]->name() << "\n";
+            return sa.take_string();
+
+        default:	// config //
+            sa << codel->_codel_target_ts.unparse().c_str() << "s, " << codel->_codel_interval_ts.unparse().c_str() << " s, ";
+            return sa.take_string();
+    }
+}
+
+void
+CoDel::add_handlers()
+{
+    add_data_handlers("drops", Handler::OP_READ, &_total_drops);
+    add_read_handler("codel_interval", read_keyword_handler, "0 CODEL_INTERVAL");
+    add_write_handler("codel_interval", reconfigure_keyword_handler, "0 CODEL_INTERVAL");
+    add_read_handler("codel_target", read_keyword_handler, "1 CODEL_TARGET");
+    add_write_handler("codel_target", reconfigure_keyword_handler, "1 CODEL_TARGET");
+    add_read_handler("stats", read_handler, 2);
+    add_read_handler("queues", read_handler, 3);
+    add_read_handler("config", read_handler, 4);
+}
+
+CLICK_ENDDECLS
+ELEMENT_REQUIRES(int64)
+EXPORT_ELEMENT(CoDel)

--- a/elements/aqm/codel.hh
+++ b/elements/aqm/codel.hh
@@ -1,0 +1,131 @@
+#ifndef CLICK_CODEL_HH
+#define CLICK_CODEL_HH
+#include <click/element.hh>
+#include <click/ewma.hh>
+#include <click/timestamp.hh>
+CLICK_DECLS
+class Storage;
+
+/*
+=c
+
+CoDel([, I<KEYWORDS>])
+
+=s aqm
+
+drops packets according to P<CoDel>
+
+=d
+
+Implements CoDel (Controlled Delay) active queue management
+mechanism.
+
+A CoDel element is associated with one or more Storage elements (usually
+Queues). It tracks the sojourn time of every packet in the queue, and
+increases the frequency of dropping packets until the queue is controlled,
+i.e. the sojourn time goes below the threshold. The sojourn time is tracked
+based on the "first timestamp" annotation, which must be set using the
+SetTimestamp element just before the packet is enqueued. Later, CoDel overwrites
+this annotation with the sojourn time experienced by the corresponding
+packet for (possible) statistical use thereafter.
+
+By default, the Queues are found with flow-based router context and only the
+upstream queues are searched. CoDel is a pull element.
+
+Arguments are:
+
+=over 8
+
+=item TARGET
+
+Integer. Target sojourn time of the packet in the queue, default value is 5 ms.
+
+=item INTERVAL
+
+Integer. Sliding minimum window width, the default value is 100 ms.
+
+=item QUEUES
+
+This argument is a space-separated list of Storage element names. CoDel will use
+those elements' queue lengths, rather than any elements found via flow-based
+router context.
+
+=back
+
+
+=e
+
+  ... -> SetTimestamp(FIRST true) -> Queue(200) -> CoDel(5, 100) -> ...
+
+
+=h target read/write
+
+Returns or sets the TARGET configuration parameter.
+
+=h interval read/write
+
+Returns or sets the INTERVAL configuration parameter.
+
+=h queues read-only
+
+Returns the Queues associated with this CoDel element, listed one per line.
+
+=h drops read-only
+
+Returns the number of packets dropped so far.
+
+=h stats read-only
+
+Returns some human-readable statistics.
+
+=a Queue, SetTimestamp
+
+Kathleen Nichols and Van Jacobson. I<Controlling Queue Delay>.
+ACM Queue, 2012, vol.10, no.5. L<http://queue.acm.org/detail.cfm?id=2209336>
+
+Appendix: CoDel Pseudocode. L<http://queue.acm.org/appendices/codel.html>. */
+
+class CoDel : public Element { public:
+
+    CoDel() CLICK_COLD;
+    ~CoDel() CLICK_COLD;
+
+    const char *class_name() const		{ return "CoDel"; }
+    const char *port_count() const		{ return PORTS_1_1; }
+    const char *processing() const		{ return PULL; }
+
+
+    int queue_size() const;
+    int drops() const                           { return _total_drops; }
+
+    int configure(Vector<String> &conf, ErrorHandler *errh) CLICK_COLD;
+    int initialize(ErrorHandler *errh) CLICK_COLD;
+    bool can_live_reconfigure() const           { return true; }
+    void add_handlers() CLICK_COLD;
+
+    void handle_drop(Packet *);
+    Packet *pull(int port);
+
+  protected:
+
+    Storage *_queue1;
+    Vector<Storage *> _queues;
+
+    int _total_drops;
+    int _state_drops;
+    Timestamp _first_above_time, _drop_next;
+    bool _dropping;
+    bool _ok_to_drop;
+
+    Timestamp _codel_interval_ts, _codel_target_ts;
+    Vector<Element *> _queue_elements;
+
+    Packet * delegate_codel();
+    Timestamp control_law(Timestamp);
+    Packet * dequeue_and_track_sojourn_time(Timestamp, bool &);
+    static String read_handler(Element *, void *) CLICK_COLD;
+    int finish_configure(const String &queues, ErrorHandler *errh);
+};
+
+CLICK_ENDDECLS
+#endif


### PR DESCRIPTION
CoDel implementation for AQM to mitigate bufferbloat. Drops packets from the queue based on the
sojourn time of the packet in the queue.
Searches the nearest upstream storage element first (eg Queue) and acts on that. If downstream
not found, then looks for the upstream element. It needs the "SetTimestamp" element prior
to the 'Queue', which sets the "first timestamp" annotation. CoDel then uses this annotation
to track the sojourn time, and then later overwrites it with the resulting sojourn time for
possible analysis thereafter.
Ref: http://queue.acm.org/detail.cfm?id=2209336

Signed-off-by: Apurv Bhartia apurv@meraki.com
