### PR TITLE
aqm/codel: remove timestamp update from pull

### DIFF
--- a/elements/aqm/codel.cc
+++ b/elements/aqm/codel.cc
@@ -125,13 +125,7 @@ CoDel::handle_drop(Packet *p)
 Packet *
 CoDel::pull(int)
 {
-    Packet *pkt = delegate_codel();
-
-    // set the queue delay in the packet for stats later
-    if(pkt != NULL) {
-        SET_FIRST_TIMESTAMP_ANNO(pkt, (Timestamp::now() - FIRST_TIMESTAMP_ANNO(pkt)));
-    }
-    return pkt;
+    return delegate_codel();
 }
 
 // helper: pull a packet, and tracks if the sojourn time of the packet is above the target //


### PR DESCRIPTION
This can be accomplished by adding a SetTimestampDelta, so no need to do it
here.  Furthermore, it does not check to see whether the Timestamp was empty
or not, so it is setting a weird Timestamp on packets that might have just
been passed-through.

Signed-off-by: Derrick Pallas pallas@meraki.com
