### PR TITLE
RecycledSkbPool ♲ nits

### DIFF
--- a/config-linuxmodule.h.in
+++ b/config-linuxmodule.h.in
@@ -157,6 +157,9 @@
 /* Define if you have the skb_recycle function. */
 #undef HAVE_SKB_RECYCLE
 
+/* Define if you have the skb_recycle_check function. */
+#undef HAVE_SKB_RECYCLE_CHECK
+
 /* Define if you have the strnlen function. */
 #define HAVE_STRNLEN 1
 

--- a/configure.in
+++ b/configure.in
@@ -1642,6 +1642,12 @@ void f1(int64_t) { // will fail if long long and int64_t are the same type
         AC_DEFINE([HAVE_SKB_RECYCLE], [1], [Define if you have the skb_recycle function.])
     fi
 
+    AC_CHECK_DECL([skb_recycle_check], [ac_cv_skb_recycle_check=yes], [ac_cv_skb_recycle_check=no], [CLICK_LINUXMODULE_PROLOGUE()[
+#include <linux/skbuff.h>]])
+    if test $ac_cv_skb_recycle_check = yes; then
+        AC_DEFINE([HAVE_SKB_RECYCLE_CHECK], [1], [Define if you have the skb_recycle_check function.])
+    fi
+
 save_cflags="$CFLAGS"
 CFLAGS="$save_cflags -Werror-implicit-function-declaration"
 

--- a/linuxmodule/skbmgr.cc
+++ b/linuxmodule/skbmgr.cc
@@ -302,10 +302,10 @@ RecycledSkbPool::recycle(struct sk_buff *skbs)
 	  _buckets[bucket]._skbs[tail] = skb;
 	  _buckets[bucket]._tail = next;
 	  skb = 0;
-	}
 # if DEBUG_SKBMGR
-        _recycle_freed++;
+          _recycle_freed++;
 # endif
+	}
       }
       unlock();
     }

--- a/linuxmodule/skbmgr.cc
+++ b/linuxmodule/skbmgr.cc
@@ -226,6 +226,14 @@ RecycledSkbPool::size_to_higher_bucket(unsigned size)
 }
 
 inline unsigned
+RecycledSkbPool::size_to_lower_bucket_size(unsigned size)
+{
+  if (size >= 1800) return 1800;
+  if (size >= 500) return 500;
+  return size;
+}
+
+inline unsigned
 RecycledSkbPool::size_to_higher_bucket_size(unsigned size)
 {
   if (size <= 500) return 500;
@@ -282,7 +290,7 @@ RecycledSkbPool::recycle(struct sk_buff *skbs)
     struct sk_buff *skb = skbs;
     skbs = skbs->next;
 
-#if HAVE_CLICK_SKB_RECYCLE
+#if HAVE_CLICK_SKB_RECYCLE || HAVE_SKB_RECYCLE_CHECK
     // where should sk_buff go?
 # if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24)
     unsigned char *skb_end = skb_end_pointer(skb);
@@ -297,8 +305,12 @@ RecycledSkbPool::recycle(struct sk_buff *skbs)
       int tail = _buckets[bucket]._tail;
       int next = _buckets[bucket].next_i(tail);
       if (next != _buckets[bucket]._head) {
+#if HAVE_CLICK_SKB_RECYCLE
 	// Note: skb_recycle_fast will free the skb if it cannot recycle it
 	if ((skb = skb_recycle(skb))) {
+#elif HAVE_SKB_RECYCLE_CHECK
+	if (skb_recycle_check(skb, size_to_lower_bucket_size(skb_end - skb->head))) {
+#endif
 	  _buckets[bucket]._skbs[tail] = skb;
 	  _buckets[bucket]._tail = next;
 	  skb = 0;


### PR DESCRIPTION
One commit fixes the accounting for recycled SKBs, the other makes recycling work in kernels up to 3.6. For newer kernels, skb_recycle_check & friends should be patched into the kernel.

Reduce→reuse→recycle, & close the loop. ♲