### PR TITLE
sync/ReadWriteLock: account for actual cache line size

### DIFF
--- a/include/click/sync.hh
+++ b/include/click/sync.hh
@@ -419,10 +419,12 @@ class ReadWriteLock { public:
 
 #if CLICK_LINUXMODULE && defined(CONFIG_SMP)
   private:
-    // allocate 32 bytes (size of a cache line) for every member
+    // allocate a cache line for every member
     struct lock_t {
-	Spinlock _lock;
-	unsigned char reserved[32 - sizeof(Spinlock)];
+	union {
+	    Spinlock _lock;
+	    unsigned char reserved[L1_CACHE_BYTES];
+	};
     } *_l;
 #endif
 


### PR DESCRIPTION
This code wants every Spinlock in the ReadWriteLock to occupy its own cache
line.  The way it is currently done is buggy.  First, L1 cache lines are not
always 32 bytes.  Second, if a Spinlock were larger than a cache line, the
code would not compile.

This change fixes the first issue by using L1_CACHE_BYTES and the second
with an anoymous union.

Signed-off-by: Derrick Pallas <pallas@meraki.com>