### PR TITLE
VLANEncap and VLANDecap: Custom VLAN ethertype

### DIFF
--- a/elements/ethernet/vlandecap.cc
+++ b/elements/ethernet/vlandecap.cc
@@ -35,8 +35,10 @@ int
 VLANDecap::configure(Vector<String> &conf, ErrorHandler *errh)
 {
     _anno = true;
+    _ethertype = ETHERTYPE_8021Q;
     return Args(conf, this, errh)
 	.read_p("ANNO", _anno)
+        .read("ETHERTYPE", _ethertype)
         .complete();
 }
 
@@ -46,7 +48,7 @@ VLANDecap::simple_action(Packet *p)
     assert(!p->mac_header() || p->mac_header() == p->data());
     uint16_t tci = 0;
     const click_ether_vlan *vlan = reinterpret_cast<const click_ether_vlan *>(p->data());
-    if (vlan->ether_vlan_proto == htons(ETHERTYPE_8021Q)) {
+    if (vlan->ether_vlan_proto == htons(_ethertype)) {
 	tci = vlan->ether_vlan_tci;
 	if (WritablePacket *q = p->uniqueify()) {
 	    memmove(q->data() + 4, q->data(), 12);

--- a/elements/ethernet/vlandecap.hh
+++ b/elements/ethernet/vlandecap.hh
@@ -7,7 +7,7 @@ CLICK_DECLS
 /*
 =c
 
-VLANDecap([ANNO])
+VLANDecap(I<keywords>])
 
 =s ethernet
 
@@ -19,8 +19,18 @@ Expects a potentially 802.1Q VLAN encapsulated packet as input.  If it is
 encapsulated, then the encapsulation is stripped, leaving a conventional
 Ethernet packet.
 
+Keyword arguments are:
+
+=item ANNO
+
 If ANNO is true (the default), then the VLAN_TCI annotation is set to the VLAN
 TCI in network byte order, or 0 if the packet was not VLAN-encapsulated.
+
+=item ETHERTYPE
+
+Specifies the ethertype designating VLAN encapsulated packets. The default is
+0x8100 (standard 802.1Q customer VLANs); other useful values are 0x88a8 (for
+802.1ad service VLANs, aka QinQ) and 0x9100 (old non-standard VLANs).
 
 =a
 
@@ -41,6 +51,7 @@ class VLANDecap : public Element { public:
 private:
 
     bool _anno;
+    uint16_t _ethertype;
 
 };
 

--- a/elements/ethernet/vlanencap.hh
+++ b/elements/ethernet/vlanencap.hh
@@ -44,6 +44,12 @@ NATIVE_VLAN, then the output packet is encapsulated in a conventional Ethernet
 header, rather than an 802.1Q header (i.e., the shim header is not added).
 Set to -1 for no native VLAN.  Defaults to 0.
 
+=item ETHERTYPE
+
+Specifies the ethertype designating VLAN encapsulated packets. The default is
+0x8100 (standard 802.1Q customer VLANs); other useful values are 0x88a8 (for
+802.1ad service VLANs, aka QinQ) and 0x9100 (old non-standard VLANs).
+
 =a
 
 EtherVLANEncap, VLANDecap
@@ -67,6 +73,7 @@ class VLANEncap : public Element { public:
     uint16_t _vlan_tci;
     bool _use_anno;
     int _native_vlan;
+    uint16_t _ethertype;
 
     enum { h_config, h_vlan_tci };
     static String read_handler(Element *e, void *user_data) CLICK_COLD;

--- a/test/ethernet/VLANEncap-01.testie
+++ b/test/ethernet/VLANEncap-01.testie
@@ -1,0 +1,33 @@
+%script
+click CONFIG
+
+%file CONFIG
+InfiniteSource(DATA \<AAABACAD>, LIMIT 1, STOP true)
+  -> Print(x)
+  -> EtherEncap(0x0800, 1:1:1:1:1:1, 2:2:2:2:2:2)
+  -> VLANEncap(1)
+  -> Print(a)
+  -> VLANDecap()
+  -> Strip(14)
+  -> Print(b)
+  -> EtherEncap(0x0800, 1:1:1:1:1:1, 2:2:2:2:2:2)
+  -> VLANEncap(ANNO)
+  -> Print(c)
+  -> VLANDecap()
+  -> Print(d)
+  -> VLANEncap(ANNO, NATIVE_VLAN 1)
+  -> Print(e)
+  -> VLANDecap()
+  -> SetVLANAnno(2, 1)
+  -> VLANEncap(ANNO, NATIVE_VLAN 1)
+  -> Print(f)
+  -> Discard;
+
+%expect stderr
+x:    4 | aaabacad
+a:   22 | 02020202 02020101 01010101 81000001 0800aaab acad
+b:    4 | aaabacad
+c:   22 | 02020202 02020101 01010101 81000001 0800aaab acad
+d:   18 | 02020202 02020101 01010101 0800aaab acad
+e:   18 | 02020202 02020101 01010101 0800aaab acad
+f:   22 | 02020202 02020101 01010101 81002002 0800aaab acad

--- a/test/ethernet/VLANEncap-02.testie
+++ b/test/ethernet/VLANEncap-02.testie
@@ -1,0 +1,20 @@
+%script
+click CONFIG
+
+%file CONFIG
+InfiniteSource(DATA \<AAABACAD>, LIMIT 1, STOP true)
+  -> Print(x)
+  -> EtherEncap(0x0800, 1:1:1:1:1:1, 2:2:2:2:2:2)
+  -> VLANEncap(0x1234, ETHERTYPE 0x88a8)
+  -> Print(a)
+  -> VLANDecap()
+  -> Print(b)
+  -> VLANDecap(ETHERTYPE 0x88a8)
+  -> Print(c)
+  -> Discard;
+
+%expect stderr
+x:    4 | aaabacad
+a:   22 | 02020202 02020101 01010101 88a81234 0800aaab acad
+b:   22 | 02020202 02020101 01010101 88a81234 0800aaab acad
+c:   18 | 02020202 02020101 01010101 0800aaab acad


### PR DESCRIPTION
This adds support for non-standard VLAN ethertypes (ethertypes other than 0x8100), e.g. 0x88A8 for 802.1ad (QinQ) to VLANEncap and VLANDecap.

Tests are included for old and new VLANEncap/VLANDecap functionality.