### PR TITLE
linuxmodule: todevice: fix use after free when reallocating for more headroom

### DIFF
--- a/elements/linuxmodule/todevice.cc
+++ b/elements/linuxmodule/todevice.cc
@@ -548,7 +548,7 @@ ToDevice::queue_packet(Packet *p, struct netdev_queue *txq)
 
  enqueued:
     if (ret != 0) {
-        _q = p;
+        _q = (Packet*)skb1;
 	_q_expiry_j = click_jiffies() + queue_timeout;
         if (++_holds == 1)
             printk("<1>ToDevice %s is full, packet delayed\n", dev->name);


### PR DESCRIPTION
Earlier in queue_packet, a packet may have been reallocated to expand
the headroom. If a packet is both reallocated *and* the call to the xmit
function fails, this code queues up the freed packet instead of the new
skb.

This change is to always queue up skb1 instead of p, which may not be
valid anymore.

I'm not sure if I should use Packet::make here, or maybe even just drop the packet in this case?