### PR TITLE
fix multiple it_present flags

### DIFF
--- a/elements/wifi/radiotapdecap.cc
+++ b/elements/wifi/radiotapdecap.cc
@@ -130,7 +130,7 @@ RadiotapDecap::simple_action(Packet *p)
 	}
 
 	struct click_wifi_extra *ceh = WIFI_EXTRA_ANNO(p);
-	if (rt_check_header(th, p->length(), offsets)) {
+	if (rt_check_header(th, p->length(), offsets, additional_it_present_flags)) {
 		memset((void*)ceh, 0, sizeof(struct click_wifi_extra));
 		ceh->magic = WIFI_EXTRA_MAGIC;
 


### PR DESCRIPTION
this patch tries to solve the issue #180 it is maybe also the solution for #172 .

If a wifi device has multiple antennas and the driver supports it, it may happen that in the radiotap header are several it_present fields. With my hardware an atheros card using ath9k I had 4 it_present fields. For each antenna it tracked the RSSI. Without the patch click accessed the wrong position in the packet.

The only problem that still exists is that just the first RSSI (first it_present field) is stored in the WIFI_EXTRA_ANNO structure. I am not sure how to implement it in the right way.

The 802.11ac cards need to support MIMO therefore it has at least two antennas and may lead to the issue described in #172 .