### PR TITLE
preempt_enable_no_resched() is undefined since kernel 3.14

### DIFF
--- a/lib/master.cc
+++ b/lib/master.cc
@@ -234,7 +234,7 @@ Master::kill_router(Router *router)
 
     unpause();
 #if CLICK_LINUXMODULE
-    preempt_enable_no_resched();
+    preempt_enable();
 #endif
 
     // something has happened, so wake up threads

--- a/lib/master.cc
+++ b/lib/master.cc
@@ -234,7 +234,11 @@ Master::kill_router(Router *router)
 
     unpause();
 #if CLICK_LINUXMODULE
+#  if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
     preempt_enable();
+#  else
+    preempt_enable_no_resched();
+#  endif
 #endif
 
     // something has happened, so wake up threads


### PR DESCRIPTION
The related kernel patch is : 
https://lkml.org/lkml/2013/11/20/416

Looking at that patch it seems that preempt_enable() is equivalent to the old preempt_enable_no_resched(), so this should be fine.