### PR TITLE
Support netmap when pcap is not available

### DIFF
--- a/elements/userlevel/fromdevice.cc
+++ b/elements/userlevel/fromdevice.cc
@@ -469,7 +469,7 @@ FromDevice::emit_packet(WritablePacket *p, int extra_len, const Timestamp &ts)
 }
 #endif
 
-#if FROMDEVICE_ALLOW_PCAP
+#if FROMDEVICE_ALLOW_PCAP || FROMDEVICE_ALLOW_NETMAP
 CLICK_ENDDECLS
 extern "C" {
 void

--- a/elements/userlevel/fromdevice.hh
+++ b/elements/userlevel/fromdevice.hh
@@ -15,7 +15,6 @@ extern "C" {
 # if HAVE_PCAP_SETNONBLOCK && !HAVE_DECL_PCAP_SETNONBLOCK
 int pcap_setnonblock(pcap_t *p, int nonblock, char *errbuf);
 # endif
-void FromDevice_get_packet(u_char*, const struct pcap_pkthdr*, const u_char*);
 }
 #endif
 
@@ -26,6 +25,9 @@ void FromDevice_get_packet(u_char*, const struct pcap_pkthdr*, const u_char*);
 
 #if FROMDEVICE_ALLOW_NETMAP || FROMDEVICE_ALLOW_PCAP
 # include <click/task.hh>
+extern "C" {
+void FromDevice_get_packet(u_char*, const struct pcap_pkthdr*, const u_char*);
+}
 #endif
 
 CLICK_DECLS
@@ -227,12 +229,14 @@ class FromDevice : public Element { public:
 #if FROMDEVICE_ALLOW_PCAP
     pcap_t *_pcap;
     int _pcap_complaints;
-    friend void FromDevice_get_packet(u_char*, const struct pcap_pkthdr*,
-				      const u_char*);
 #endif
 #if FROMDEVICE_ALLOW_NETMAP
     NetmapInfo _netmap;
     int netmap_dispatch();
+#endif
+#if FROMDEVICE_ALLOW_PCAP || FROMDEVICE_ALLOW_NETMAP
+    friend void FromDevice_get_packet(u_char*, const struct pcap_pkthdr*,
+                                      const u_char*);
 #endif
 
     bool _force_ip;


### PR DESCRIPTION
Both the NetmapInfo::dispatch and pcap_dispatch require FromDevice_get_packet. If libpcap is not available, neither is FromDevice_get_packet (and click doesn't compile).