### PR TITLE
Be a little more cautious in click_max_cpu_ids

### DIFF
--- a/include/click/glue.hh
+++ b/include/click/glue.hh
@@ -428,10 +428,10 @@ click_max_cpu_ids()
 {
 #if CLICK_LINUXMODULE
     return NR_CPUS;
-#elif CLICK_USERLEVEL
+#elif CLICK_USERLEVEL && HAVE___THREAD_STORAGE_CLASS
     return click_nthreads;
 #else //XXX BSDMODULE?
-    return 1;
+    return CLICK_CPU_MAX;
 #endif
 }
 


### PR DESCRIPTION
Following recommendation in PR #191 :

If there isn't support for thread-local storage in userlevel, we rely on
sched_getcpu() (current cpu id) in click_current_cpu_id() which could be upper than
click_nthreads (number of threads that click uses). As for the BSD mode we'll
use CLICK_CPU_MAX as an upper bound for the current cpu id which is equal to 256
when MT is enabled and 1 when it isn't.