### PR TITLE
Force PCAP to use TPACKET_V2 instead of TPACKET_V3.

### DIFF
--- a/config-userlevel.h.in
+++ b/config-userlevel.h.in
@@ -38,6 +38,10 @@
    of 'pcap_setnonblock', and to 0 if you don't. */
 #undef HAVE_DECL_PCAP_SETNONBLOCK
 
+/* Define to 1 if you have the declaration
+ *    of 'pcap_set_immediate_mode', and to 0 if you don't. */
+#undef HAVE_DECL_PCAP_SET_IMMEDIATE_MODE
+
 /* Define if you have the <dlfcn.h> header file. */
 #undef HAVE_DLFCN_H
 
@@ -139,6 +143,9 @@
 
 /* Define if you have the pcap_setnonblock function. */
 #undef HAVE_PCAP_SETNONBLOCK
+
+/* Define if you have the pcap_set_immediate_mode function. */
+#undef HAVE_PCAP_SET_IMMEDIATE_MODE
 
 /* Define if you have -lproper and prop.h, and proper operations should be
    preferred to their non-proper counterparts. */

--- a/configure
+++ b/configure
@@ -10416,6 +10416,18 @@ cat >>confdefs.h <<_ACEOF
 #define HAVE_DECL_PCAP_SETNONBLOCK $ac_have_decl
 _ACEOF
 
+        ac_fn_cxx_check_decl "$LINENO" "pcap_set_immediate_mode" "ac_cv_have_decl_pcap_set_immediate_mode" "#include <pcap.h>
+"
+if test "x$ac_cv_have_decl_pcap_set_immediate_mode" = xyes; then :
+  ac_have_decl=1
+else
+  ac_have_decl=0
+fi
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_PCAP_SET_IMMEDIATE_MODE $ac_have_decl
+_ACEOF
+
         CPPFLAGS="$saveflags"
     fi
 
@@ -10563,7 +10575,7 @@ $as_echo "#define HAVE_PCAP 1" >>confdefs.h
 
         savelibs="$LIBS"
         LIBS="$savelibs $PCAP_LIBS"
-        for ac_func in pcap_inject pcap_sendpacket pcap_setdirection pcap_setnonblock
+        for ac_func in pcap_inject pcap_sendpacket pcap_setdirection pcap_setnonblock pcap_set_immediate_mode
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/elements/userlevel/fromdevice.cc
+++ b/elements/userlevel/fromdevice.cc
@@ -275,6 +275,11 @@ FromDevice::open_pcap(String ifname, int snaplen, bool promisc,
     (void) pcap_set_tstamp_precision(p, PCAP_TSTAMP_PRECISION_NANO);
 # endif
 
+# if HAVE_PCAP_SET_IMMEDIATE_MODE
+    if (pcap_set_immediate_mode(p, 1))
+        errh->warning("%s: error while setting immediate mode", ifname.c_str());
+# endif
+
     // activate pcap
     int r = pcap_activate(p);
     if (r < 0) {


### PR DESCRIPTION
As from libpcap 1.5.0 the default is to use TPACKET_V3 if available in the kernel.
However TPACKET_V3 is catered for better packet capture and less packet drops,
but is not suitable for capture and transmit scenarios as it introduces significant
latency when forwarding packets in userlevel Click using FromDevice with METHOD PCAP.
Setting pcap_set_immediate_mode forces PCAP to fall back to TPACKET_V2 in immediate mode.

See the following references for more information:

http://seclists.org/tcpdump/2014/q4/53
http://seclists.org/tcpdump/2014/q1/122

Resolves issue #164