### PR TITLE
Fix compiler warnings (clang)

### DIFF
--- a/elements/ns/tosimtrace.cc
+++ b/elements/ns/tosimtrace.cc
@@ -37,7 +37,7 @@
 CLICK_DECLS
 
 ToSimTrace::ToSimTrace()
-                : _packetAnalyzer(0), _offset(0), _checkPaint(false)
+                : _packetAnalyzer(0), _offset(0)
 {
         additional_info_ = "";
 }

--- a/elements/ns/tosimtrace.hh
+++ b/elements/ns/tosimtrace.hh
@@ -50,7 +50,6 @@ private:
   SimPacketAnalyzer *_packetAnalyzer;
   String	_encap;
   int		_offset;
-  bool		_checkPaint;
 
 };
 

--- a/elements/standard/averagecounter.hh
+++ b/elements/standard/averagecounter.hh
@@ -66,7 +66,6 @@ class AverageCounter : public Element { public:
     atomic_uint32_t _byte_count;
     atomic_uint32_t _first;
     atomic_uint32_t _last;
-    atomic_uint32_t _first_count;
     uint32_t _ignore;
 
 };

--- a/elements/tcpudp/dynudpipencap.hh
+++ b/elements/tcpudp/dynudpipencap.hh
@@ -39,7 +39,9 @@ class DynamicUDPIPEncap : public Element {
   uint16_t _sport;
   uint16_t _dport;
   bool _cksum : 1;
+#ifdef CLICK_LINUXMODULE
   bool _aligned : 1;
+#endif
   atomic_uint32_t _id;
   atomic_uint32_t _count;
   unsigned _interval;

--- a/elements/test/checkpacket.hh
+++ b/elements/test/checkpacket.hh
@@ -77,7 +77,6 @@ class CheckPacket : public Element { public:
     uint32_t _length;
     uint8_t _data_op;
     uint8_t _length_op;
-    bool _do_align : 1;
 
 };
 

--- a/elements/userlevel/fromdevice.hh
+++ b/elements/userlevel/fromdevice.hh
@@ -220,9 +220,6 @@ class FromDevice : public Element { public:
 #if FROMDEVICE_ALLOW_NETMAP || FROMDEVICE_ALLOW_PCAP
     Task _task;
 #endif
-#if FROMDEVICE_ALLOW_LINUX
-    unsigned char *_linux_packetbuf;
-#endif
 #if FROMDEVICE_ALLOW_PCAP || FROMDEVICE_ALLOW_NETMAP
     void emit_packet(WritablePacket *p, int extra_len, const Timestamp &ts);
 #endif


### PR DESCRIPTION
This patch fixes compiler warnings (if clang is used). You can see the warning in the travis-logs (https://travis-ci.org/kohler/click/jobs/76707013).