### PR TITLE
Add DPDK Support

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -351,19 +351,19 @@ and loading the DPDK module, e.g.
 
 Refer to the DPDK documentation for more details.
 
-DPDK EAL arguments must be used before Click's own arguments. At least the
-following two arguments must be provided:
+Like with any other DPDK application, you have to pass DPDK EAL arguments first,
+append "--", then pass Click arguments. As the DPDK EAL will handle thread
+management instead of Click, Click's `-j` (or `--threads`) argument will be
+disabled when --enable-dpdk is provided, and you must at least give the
+following two EAL arguments, even if running on a single core :
 
     -c COREMASK : hexadecimal bitmask of cores to run on
     -n NUM      : number of memory channels
 
-Note that Click's `-j` (or `--threads`) argument is not used in DPDK mode. The
-number of threads is set indirectly through the `-c` argument.
-
 A sample command to run a click configuration on 4 cores on a computer with
-4 memory channels could be:
+4 memory channels and listen for control connections on TCP port 8080 would be :
 
-    click -c 0xf -n 4 configfile
+    click -c 0xf -n 4 -- -p 8080 configfile
 
 
 CLICKY GUI

--- a/INSTALL
+++ b/INSTALL
@@ -328,6 +328,42 @@ have a look at the following Xen toolstack:
 	http://github.com/cnplab/cosmos
 
 
+DPDK
+----
+Support for using Intel DPDK for high speed userspace I/O is enabled using
+
+    ./configure --enable-dpdk --enable-user-multithread --disable-linuxmodule
+
+In order to configure and compile properly, the RTE_SDK and RTE_TARGET
+environment variable must be set, e.g.
+
+    export RTE_SDK=/path/to/dpdk-2.1.0/
+    export RTE_TARGET=x86_64-native-linuxapp-gcc
+
+Before running, DPDK must be set up properly, including support for huge pages
+and loading the DPDK module, e.g.
+
+    echo 1024 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+    mkdir -p /mnt/huge
+    mount -t hugetlbfs nodev /mnt/huge
+    /sbin/insmod "$RTE_SDK/$RTE_TARGET/kmod/igb_uio.ko
+
+Refer to the DPDK documentation for more details.
+
+DPDK EAL arguments must be used before Click's own arguments. At least the
+following two arguments must be provided:
+
+    -c COREMASK : hexadecimal bitmask of cores to run on
+    -n NUM      : number of memory channels
+
+Note that Click's `-j` (or `--threads`) argument is not used in DPDK mode. The
+number of threads is set indirectly through the `-c` argument.
+
+A sample command to run a click configuration on 4 cores on a computer with
+4 memory channels could be:
+
+    click -c 0xf -n 4 configfile
+
 CLICKY GUI
 ----------
 

--- a/INSTALL
+++ b/INSTALL
@@ -330,15 +330,16 @@ have a look at the following Xen toolstack:
 
 DPDK
 ----
-Support for using Intel DPDK for high speed userspace I/O is enabled using
 
-    ./configure --enable-dpdk --enable-user-multithread --disable-linuxmodule
+Support for using Intel DPDK for high-speed userspace I/O is enabled using
 
-In order to configure and compile properly, the RTE_SDK and RTE_TARGET
-environment variable must be set, e.g.
+    ./configure RTE_SDK=... RTE_TARGET=... \
+        --enable-dpdk --enable-user-multithread --disable-linuxmodule
 
-    export RTE_SDK=/path/to/dpdk-2.1.0/
-    export RTE_TARGET=x86_64-native-linuxapp-gcc
+where RTE_SDK and RTE_TARGET are defined as per the DPDK documentation, e.g.
+
+    RTE_SDK=/path/to/dpdk-2.1.0/
+    RTE_TARGET=x86_64-native-linuxapp-gcc
 
 Before running, DPDK must be set up properly, including support for huge pages
 and loading the DPDK module, e.g.
@@ -363,6 +364,7 @@ A sample command to run a click configuration on 4 cores on a computer with
 4 memory channels could be:
 
     click -c 0xf -n 4 configfile
+
 
 CLICKY GUI
 ----------

--- a/config-userlevel.h.in
+++ b/config-userlevel.h.in
@@ -214,6 +214,9 @@
 /* Define if a Click user-level driver might run multiple threads. */
 #undef HAVE_USER_MULTITHREAD
 
+/* Define if a Click user-level driver uses Intel DPDK. */
+#undef HAVE_DPDK
+
 /* Define if Click should use Valgrind client requests. */
 #undef HAVE_VALGRIND
 

--- a/configure
+++ b/configure
@@ -702,6 +702,9 @@ minios_dir
 xen_dir
 INCLUDE_KSYMS
 LINUXMODULE_FIXINCLUDES
+USE_DPDK
+RTE_VER_MINOR
+RTE_VER_MAJOR
 PTHREAD_LIBS
 AR_CREATEFLAGS
 STRIP
@@ -764,6 +767,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -791,6 +795,7 @@ enable_user_multithread
 enable_select
 enable_poll
 enable_kqueue
+enable_dpdk
 enable_linuxmodule
 enable_fixincludes
 enable_multithread
@@ -899,6 +904,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1151,6 +1157,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1288,7 +1303,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1441,6 +1456,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1483,6 +1499,7 @@ Optional Features:
     --disable-select      do not use select()
     --disable-poll        do not use poll()
     --disable-kqueue      do not use kqueue()
+    --enable-dpdk         use Intel DPDK
   --disable-linuxmodule   disable Linux kernel driver
     --disable-fixincludes do not patch Linux kernel headers for C++
     --enable-multithread  support kernel multithreading
@@ -6475,6 +6492,53 @@ fi
 if echo "$enable_select" | grep kqueue >/dev/null 2>&1 && test "$enable_kqueue" = yes; then
 
 $as_echo "#define HAVE_ALLOW_KQUEUE 1" >>confdefs.h
+
+fi
+
+# Check whether --enable-dpdk was given.
+if test "${enable_dpdk+set}" = set; then :
+  enableval=$enable_dpdk; :
+else
+  enable_dpdk=no
+fi
+
+
+if test "x$enable_dpdk" = xyes; then
+    if test "x$enable_user_multithread" != xyes; then
+        as_fn_error $? "
+=========================================
+
+--enable-dpdk requires --enable-user-multithread which was not provided.
+
+=========================================" "$LINENO" 5
+    fi
+    if test ! -f "$RTE_SDK/$RTE_TARGET/include/rte_eal.h"; then
+        as_fn_error $? "
+=========================================
+
+Cannot find \$RTE_SDK/\$RTE_TARGET/include/rte_eal.h for Intel DPDK.
+Define \$RTE_SDK and \$RTE_TARGET as per Intel DPDK documentation.
+
+=========================================" "$LINENO" 5
+    fi
+    if test ! -f "$RTE_SDK/$RTE_TARGET/lib/librte_eal.a"; then
+        as_fn_error $? "
+=========================================
+
+Cannot find \$RTE_SDK/\$RTE_TARGET/lib/librte_eal.a for Intel DPDK.
+Define \$RTE_SDK and \$RTE_TARGET as per Intel DPDK documentation.
+
+=========================================" "$LINENO" 5
+    fi
+    rte_ver_major=`grep "#define RTE_VER_MAJOR" "$RTE_SDK/$RTE_TARGET/include/rte_version.h" | head -n 1 | awk '{print $3}'`
+    rte_ver_minor=`grep "#define RTE_VER_MINOR" "$RTE_SDK/$RTE_TARGET/include/rte_version.h" | head -n 1 | awk '{print $3}'`
+    RTE_VER_MAJOR=$rte_ver_major
+
+    RTE_VER_MINOR=$rte_ver_minor
+
+    $as_echo "#define HAVE_DPDK 1" >>confdefs.h
+
+    USE_DPDK=yes
 
 fi
 
@@ -13310,6 +13374,10 @@ esac
 
 if test "x$enable_analysis" = xyes; then
     provisions="$provisions analysis"
+fi
+
+if test "x$enable_dpdk" = xyes; then
+    provisions="$provisions dpdk"
 fi
 
 if test "x$enable_experimental" = xyes; then

--- a/configure
+++ b/configure
@@ -705,6 +705,8 @@ LINUXMODULE_FIXINCLUDES
 USE_DPDK
 RTE_VER_MINOR
 RTE_VER_MAJOR
+RTE_TARGET
+RTE_SDK
 PTHREAD_LIBS
 AR_CREATEFLAGS
 STRIP
@@ -6532,6 +6534,8 @@ Define \$RTE_SDK and \$RTE_TARGET as per Intel DPDK documentation.
     fi
     rte_ver_major=`grep "#define RTE_VER_MAJOR" "$RTE_SDK/$RTE_TARGET/include/rte_version.h" | head -n 1 | awk '{print $3}'`
     rte_ver_minor=`grep "#define RTE_VER_MINOR" "$RTE_SDK/$RTE_TARGET/include/rte_version.h" | head -n 1 | awk '{print $3}'`
+
+
     RTE_VER_MAJOR=$rte_ver_major
 
     RTE_VER_MINOR=$rte_ver_minor

--- a/configure.in
+++ b/configure.in
@@ -135,6 +135,45 @@ if echo "$enable_select" | grep kqueue >/dev/null 2>&1 && test "$enable_kqueue" 
     AC_DEFINE([HAVE_ALLOW_KQUEUE], [1], [Define if kqueue() may be used to wait for file descriptor events.])
 fi
 
+AC_ARG_ENABLE([dpdk],
+    [AS_HELP_STRING([  --enable-dpdk], [use Intel DPDK])],
+    [:], [enable_dpdk=no])
+
+if test "x$enable_dpdk" = xyes; then
+    if test "x$enable_user_multithread" != xyes; then
+        AC_MSG_ERROR([
+=========================================
+
+--enable-dpdk requires --enable-user-multithread which was not provided.
+
+=========================================])
+    fi
+    if test ! -f "$RTE_SDK/$RTE_TARGET/include/rte_eal.h"; then
+        AC_MSG_ERROR([
+=========================================
+
+Cannot find \$RTE_SDK/\$RTE_TARGET/include/rte_eal.h for Intel DPDK.
+Define \$RTE_SDK and \$RTE_TARGET as per Intel DPDK documentation.
+
+=========================================])
+    fi
+    if test ! -f "$RTE_SDK/$RTE_TARGET/lib/librte_eal.a"; then
+        AC_MSG_ERROR([
+=========================================
+
+Cannot find \$RTE_SDK/\$RTE_TARGET/lib/librte_eal.a for Intel DPDK.
+Define \$RTE_SDK and \$RTE_TARGET as per Intel DPDK documentation.
+
+=========================================])
+    fi
+    rte_ver_major=`grep "#define RTE_VER_MAJOR" "$RTE_SDK/$RTE_TARGET/include/rte_version.h" | head -n 1 | awk '{print $3}'`
+    rte_ver_minor=`grep "#define RTE_VER_MINOR" "$RTE_SDK/$RTE_TARGET/include/rte_version.h" | head -n 1 | awk '{print $3}'`
+    AC_SUBST(RTE_VER_MAJOR, $rte_ver_major)
+    AC_SUBST(RTE_VER_MINOR, $rte_ver_minor)
+    AC_DEFINE([HAVE_DPDK])
+    AC_SUBST(USE_DPDK, yes)
+fi
+
 
 dnl linuxmodule driver and features
 
@@ -1955,6 +1994,11 @@ esac
 dnl add 'analysis' if analysis elements are available
 if test "x$enable_analysis" = xyes; then
     provisions="$provisions analysis"
+fi
+
+dnl add 'dpdk' if compiled with --enable-dpdk
+if test "x$enable_dpdk" = xyes; then
+    provisions="$provisions dpdk"
 fi
 
 dnl add 'experimental' if --enable-experimental was supplied

--- a/configure.in
+++ b/configure.in
@@ -168,6 +168,8 @@ Define \$RTE_SDK and \$RTE_TARGET as per Intel DPDK documentation.
     fi
     rte_ver_major=`grep "#define RTE_VER_MAJOR" "$RTE_SDK/$RTE_TARGET/include/rte_version.h" | head -n 1 | awk '{print $3}'`
     rte_ver_minor=`grep "#define RTE_VER_MINOR" "$RTE_SDK/$RTE_TARGET/include/rte_version.h" | head -n 1 | awk '{print $3}'`
+    AC_SUBST(RTE_SDK)
+    AC_SUBST(RTE_TARGET)
     AC_SUBST(RTE_VER_MAJOR, $rte_ver_major)
     AC_SUBST(RTE_VER_MINOR, $rte_ver_minor)
     AC_DEFINE([HAVE_DPDK])

--- a/elements/userlevel/dpdkinfo.cc
+++ b/elements/userlevel/dpdkinfo.cc
@@ -1,0 +1,52 @@
+// -*- mode: c++; c-basic-offset: 4 -*-
+/*
+ * dpdkinfo.{cc,hh} -- library for interfacing with dpdk
+ *
+ * Copyright (c) 2014-2015 Cyril Soldani, University of Liège
+ * Copyright (c) 2015 Tom Barbette, University of Liège
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
+#include <click/config.h>
+#include <click/args.hh>
+#include "dpdkinfo.hh"
+
+CLICK_DECLS
+
+int DpdkInfo::configure(Vector<String> &conf, ErrorHandler *errh) {
+    if (instance) {
+        return errh->error(
+            "There can be only one instance of DpdkInfo!");
+    }
+    instance = this;
+    if (Args(conf, this, errh)
+        .read_p("NB_MBUF", DpdkDevice::NB_MBUF)
+        .read_p("MBUF_SIZE", DpdkDevice::MBUF_SIZE)
+        .read_p("MBUF_CACHE_SIZE", DpdkDevice::MBUF_CACHE_SIZE)
+        .read_p("RX_PTHRESH", DpdkDevice::RX_PTHRESH)
+        .read_p("RX_HTHRESH", DpdkDevice::RX_HTHRESH)
+        .read_p("RX_WTHRESH", DpdkDevice::RX_WTHRESH)
+        .read_p("TX_PTHRESH", DpdkDevice::TX_PTHRESH)
+        .read_p("TX_HTHRESH", DpdkDevice::TX_HTHRESH)
+        .read_p("TX_WTHRESH", DpdkDevice::TX_WTHRESH)
+        .complete() < 0)
+        return -1;
+
+    return 0;
+}
+
+DpdkInfo* DpdkInfo::instance = 0;
+
+CLICK_ENDDECLS
+
+ELEMENT_REQUIRES(dpdk)
+EXPORT_ELEMENT(DpdkInfo)

--- a/elements/userlevel/dpdkinfo.cc
+++ b/elements/userlevel/dpdkinfo.cc
@@ -22,31 +22,31 @@
 
 CLICK_DECLS
 
-int DpdkInfo::configure(Vector<String> &conf, ErrorHandler *errh) {
+int DPDKInfo::configure(Vector<String> &conf, ErrorHandler *errh) {
     if (instance) {
         return errh->error(
-            "There can be only one instance of DpdkInfo!");
+            "There can be only one instance of DPDKInfo!");
     }
     instance = this;
     if (Args(conf, this, errh)
-        .read_p("NB_MBUF", DpdkDevice::NB_MBUF)
-        .read_p("MBUF_SIZE", DpdkDevice::MBUF_SIZE)
-        .read_p("MBUF_CACHE_SIZE", DpdkDevice::MBUF_CACHE_SIZE)
-        .read_p("RX_PTHRESH", DpdkDevice::RX_PTHRESH)
-        .read_p("RX_HTHRESH", DpdkDevice::RX_HTHRESH)
-        .read_p("RX_WTHRESH", DpdkDevice::RX_WTHRESH)
-        .read_p("TX_PTHRESH", DpdkDevice::TX_PTHRESH)
-        .read_p("TX_HTHRESH", DpdkDevice::TX_HTHRESH)
-        .read_p("TX_WTHRESH", DpdkDevice::TX_WTHRESH)
+        .read("NB_MBUF", DPDKDevice::NB_MBUF)
+        .read("MBUF_SIZE", DPDKDevice::MBUF_SIZE)
+        .read("MBUF_CACHE_SIZE", DPDKDevice::MBUF_CACHE_SIZE)
+        .read("RX_PTHRESH", DPDKDevice::RX_PTHRESH)
+        .read("RX_HTHRESH", DPDKDevice::RX_HTHRESH)
+        .read("RX_WTHRESH", DPDKDevice::RX_WTHRESH)
+        .read("TX_PTHRESH", DPDKDevice::TX_PTHRESH)
+        .read("TX_HTHRESH", DPDKDevice::TX_HTHRESH)
+        .read("TX_WTHRESH", DPDKDevice::TX_WTHRESH)
         .complete() < 0)
         return -1;
 
     return 0;
 }
 
-DpdkInfo* DpdkInfo::instance = 0;
+DPDKInfo* DPDKInfo::instance = 0;
 
 CLICK_ENDDECLS
 
 ELEMENT_REQUIRES(dpdk)
-EXPORT_ELEMENT(DpdkInfo)
+EXPORT_ELEMENT(DPDKInfo)

--- a/elements/userlevel/dpdkinfo.hh
+++ b/elements/userlevel/dpdkinfo.hh
@@ -1,0 +1,92 @@
+#ifndef CLICK_DPDKINFO_HH
+#define CLICK_DPDKINFO_HH
+
+#include <click/element.hh>
+#include <click/dpdkdevice.hh>
+
+CLICK_DECLS
+
+/*
+=title DpdkInfo
+
+=c
+
+DpdkInfo()
+
+=s netdevices
+
+Set DPDK global parameters.
+
+=d
+
+Set Intel's DPDK global parameters used by FromDpdkDevice and
+ToDpdkDevice elements. See DPDK documentation for details.
+
+Arguments:
+
+=over 8
+
+=item NB_MBUF
+
+Integer.  Number of message buffers to allocate. Defaults to 524288.
+
+=item MBUF_SIZE
+
+Integer.  Size of a message buffer in bytes. Defaults to 2048 +
+RTE_PKTMBUF_HEADROOM + sizeof (struct rte_mbuf).
+
+=item MBUF_CACHE_SIZE
+
+Integer.  Number of message buffer to keep in a per-core cache. It should be
+such that NB_MBUF modulo MBUF_CACHE_SIZE == 0. Defaults to 256.
+
+=item RX_PTHRESH
+
+Integer.  RX prefetch threshold. Defaults to 8.
+
+=item RX_HTHRESH
+
+Integer.  RX host threshold. Defaults to 8.
+
+=item RX_WTHRESH
+
+Integer.  RX write-back threshold. Defaults to 4.
+
+=item TX_PTHRESH
+
+Integer.  TX prefetch threshold. Defaults to 36.
+
+=item TX_HTHRESH
+
+Integer.  TX host threshold. Defaults to 0.
+
+=item TX_WTHRESH
+
+Integer.  TX write-back threshold. Defaults to 0.
+
+=back
+
+This element is only available at user level, when compiled with DPDK
+support.
+
+=e
+
+  DpdkInfo(NB_MBUF 1048576, MBUF_SIZE 4096, MBUF_CACHE_SIZE 512)
+
+=a FromDpdkDevice, ToDpdkDevice */
+
+class DpdkInfo : public Element {
+public:
+
+    const char *class_name() const { return "DpdkInfo"; }
+
+    int configure_phase() const { return CONFIGURE_PHASE_FIRST; }
+
+    int configure(Vector<String> &conf, ErrorHandler *errh);
+
+    static DpdkInfo *instance;
+};
+
+CLICK_ENDDECLS
+
+#endif

--- a/elements/userlevel/dpdkinfo.hh
+++ b/elements/userlevel/dpdkinfo.hh
@@ -7,11 +7,11 @@
 CLICK_DECLS
 
 /*
-=title DpdkInfo
+=title DPDKInfo
 
 =c
 
-DpdkInfo()
+DPDKInfo([I<keywords> NB_MBUF, MBUF_SIZE, RX_PTHRESH, etc.])
 
 =s netdevices
 
@@ -19,10 +19,10 @@ Set DPDK global parameters.
 
 =d
 
-Set Intel's DPDK global parameters used by FromDpdkDevice and
-ToDpdkDevice elements. See DPDK documentation for details.
+Set Intel's DPDK global parameters used by FromDPDKDevice and
+ToDPDKDevice elements. See DPDK documentation for details.
 
-Arguments:
+Keyword arguments:
 
 =over 8
 
@@ -71,20 +71,20 @@ support.
 
 =e
 
-  DpdkInfo(NB_MBUF 1048576, MBUF_SIZE 4096, MBUF_CACHE_SIZE 512)
+  DPDKInfo(NB_MBUF 1048576, MBUF_SIZE 4096, MBUF_CACHE_SIZE 512)
 
-=a FromDpdkDevice, ToDpdkDevice */
+=a FromDPDKDevice, ToDPDKDevice */
 
-class DpdkInfo : public Element {
+class DPDKInfo : public Element {
 public:
 
-    const char *class_name() const { return "DpdkInfo"; }
+    const char *class_name() const { return "DPDKInfo"; }
 
     int configure_phase() const { return CONFIGURE_PHASE_FIRST; }
 
     int configure(Vector<String> &conf, ErrorHandler *errh);
 
-    static DpdkInfo *instance;
+    static DPDKInfo *instance;
 };
 
 CLICK_ENDDECLS

--- a/elements/userlevel/fromdpdkdevice.cc
+++ b/elements/userlevel/fromdpdkdevice.cc
@@ -30,45 +30,45 @@
 
 CLICK_DECLS
 
-FromDpdkDevice::FromDpdkDevice() :
+FromDPDKDevice::FromDPDKDevice() :
     _port_id(0), _queue_id(0), _promisc(true), _burst_size(32), _count(0),
     _task(this)
 {
 }
 
-FromDpdkDevice::~FromDpdkDevice()
+FromDPDKDevice::~FromDPDKDevice()
 {
 }
 
-int FromDpdkDevice::configure(Vector<String> &conf, ErrorHandler *errh)
+int FromDPDKDevice::configure(Vector<String> &conf, ErrorHandler *errh)
 {
     int n_desc = -1;
 
     if (Args(conf, this, errh)
-        .read_mp("PORT_ID", _port_id)
-        .read_p("QUEUE_ID", _queue_id)
-        .read_p("PROMISC", _promisc)
-        .read_p("BURST", _burst_size)
-        .read_p("NDESC", n_desc)
+        .read_mp("PORT", _port_id)
+        .read_p("QUEUE", _queue_id)
+        .read("PROMISC", _promisc)
+        .read("BURST", _burst_size)
+        .read("NDESC", n_desc)
         .complete() < 0)
         return -1;
 
-    return DpdkDevice::add_rx_device(
+    return DPDKDevice::add_rx_device(
         _port_id, _queue_id, _promisc, (n_desc > 0) ? n_desc : 256, errh);
 }
 
-int FromDpdkDevice::initialize(ErrorHandler *errh)
+int FromDPDKDevice::initialize(ErrorHandler *errh)
 {
     ScheduleInfo::initialize_task(this, &_task, true, errh);
 
-    return DpdkDevice::initialize(errh);
+    return DPDKDevice::initialize(errh);
 }
 
-void FromDpdkDevice::cleanup(CleanupStage)
+void FromDPDKDevice::cleanup(CleanupStage)
 {
 }
 
-bool FromDpdkDevice::run_task(Task * t)
+bool FromDPDKDevice::run_task(Task * t)
 {
     struct rte_mbuf *pkts[_burst_size];
 
@@ -77,7 +77,7 @@ bool FromDpdkDevice::run_task(Task * t)
         rte_prefetch0(rte_pktmbuf_mtod(pkts[i], void *));
         WritablePacket *p =
             Packet::make(rte_pktmbuf_mtod(pkts[i], unsigned char *),
-                         rte_pktmbuf_data_len(pkts[i]), DpdkDevice::free_pkt,
+                         rte_pktmbuf_data_len(pkts[i]), DPDKDevice::free_pkt,
                          pkts[i]);
         p->set_packet_type_anno(Packet::HOST);
 
@@ -92,21 +92,21 @@ bool FromDpdkDevice::run_task(Task * t)
     return n;
 }
 
-String FromDpdkDevice::count_handler(Element *e, void *)
+String FromDPDKDevice::count_handler(Element *e, void *)
 {
-    FromDpdkDevice *fnd = static_cast<FromDpdkDevice *>(e);
+    FromDPDKDevice *fnd = static_cast<FromDPDKDevice *>(e);
     return String(fnd->_count);
 }
 
-int FromDpdkDevice::reset_count_handler(const String &, Element *e, void *,
+int FromDPDKDevice::reset_count_handler(const String &, Element *e, void *,
                                         ErrorHandler *)
 {
-    FromDpdkDevice *fnd = static_cast<FromDpdkDevice *>(e);
+    FromDPDKDevice *fnd = static_cast<FromDPDKDevice *>(e);
     fnd->_count = 0;
     return 0;
 }
 
-void FromDpdkDevice::add_handlers()
+void FromDPDKDevice::add_handlers()
 {
 	add_read_handler("count", count_handler, 0);
 	add_write_handler("reset_count", reset_count_handler, 0,
@@ -115,5 +115,5 @@ void FromDpdkDevice::add_handlers()
 
 CLICK_ENDDECLS
 ELEMENT_REQUIRES(userlevel dpdk)
-EXPORT_ELEMENT(FromDpdkDevice)
-ELEMENT_MT_SAFE(FromDpdkDevice)
+EXPORT_ELEMENT(FromDPDKDevice)
+ELEMENT_MT_SAFE(FromDPDKDevice)

--- a/elements/userlevel/fromdpdkdevice.cc
+++ b/elements/userlevel/fromdpdkdevice.cc
@@ -1,0 +1,119 @@
+// -*- c-basic-offset: 4; related-file-name: "fromdpdkdevice.hh" -*-
+/*
+ * fromdpdkdevice.{cc,hh} -- element reads packets live from network via
+ * Intel's DPDK
+ *
+ * Copyright (c) 2014-2015 Cyril Soldani, University of Liège
+ * Copyright (c) 2015 Tom Barbette, University of Liège
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
+#include <click/config.h>
+
+#include <click/args.hh>
+#include <click/error.hh>
+#include <click/standard/scheduleinfo.hh>
+
+#include <rte_ethdev.h>
+#include <rte_mbuf.h>
+#include <rte_version.h>
+#include "fromdpdkdevice.hh"
+
+CLICK_DECLS
+
+FromDpdkDevice::FromDpdkDevice() :
+    _port_id(0), _queue_id(0), _promisc(true), _burst_size(32), _count(0),
+    _task(this)
+{
+}
+
+FromDpdkDevice::~FromDpdkDevice()
+{
+}
+
+int FromDpdkDevice::configure(Vector<String> &conf, ErrorHandler *errh)
+{
+    int n_desc = -1;
+
+    if (Args(conf, this, errh)
+        .read_mp("PORT_ID", _port_id)
+        .read_p("QUEUE_ID", _queue_id)
+        .read_p("PROMISC", _promisc)
+        .read_p("BURST", _burst_size)
+        .read_p("NDESC", n_desc)
+        .complete() < 0)
+        return -1;
+
+    return DpdkDevice::add_rx_device(
+        _port_id, _queue_id, _promisc, (n_desc > 0) ? n_desc : 256, errh);
+}
+
+int FromDpdkDevice::initialize(ErrorHandler *errh)
+{
+    ScheduleInfo::initialize_task(this, &_task, true, errh);
+
+    return DpdkDevice::initialize(errh);
+}
+
+void FromDpdkDevice::cleanup(CleanupStage)
+{
+}
+
+bool FromDpdkDevice::run_task(Task * t)
+{
+    struct rte_mbuf *pkts[_burst_size];
+
+    unsigned n = rte_eth_rx_burst(_port_id, _queue_id, pkts, _burst_size);
+    for (unsigned i = 0; i < n; ++i) {
+        rte_prefetch0(rte_pktmbuf_mtod(pkts[i], void *));
+        WritablePacket *p =
+            Packet::make(rte_pktmbuf_mtod(pkts[i], unsigned char *),
+                         rte_pktmbuf_data_len(pkts[i]), DpdkDevice::free_pkt,
+                         pkts[i]);
+        p->set_packet_type_anno(Packet::HOST);
+
+        output(0).push(p);
+    }
+    _count += n;
+
+    /* We reschedule directly, as we cannot know if there is actually packet
+     * available and DPDK has no select mechanism*/
+    t->fast_reschedule();
+
+    return n;
+}
+
+String FromDpdkDevice::count_handler(Element *e, void *)
+{
+    FromDpdkDevice *fnd = static_cast<FromDpdkDevice *>(e);
+    return String(fnd->_count);
+}
+
+int FromDpdkDevice::reset_count_handler(const String &, Element *e, void *,
+                                        ErrorHandler *)
+{
+    FromDpdkDevice *fnd = static_cast<FromDpdkDevice *>(e);
+    fnd->_count = 0;
+    return 0;
+}
+
+void FromDpdkDevice::add_handlers()
+{
+	add_read_handler("count", count_handler, 0);
+	add_write_handler("reset_count", reset_count_handler, 0,
+                          Handler::BUTTON);
+}
+
+CLICK_ENDDECLS
+ELEMENT_REQUIRES(userlevel dpdk)
+EXPORT_ELEMENT(FromDpdkDevice)
+ELEMENT_MT_SAFE(FromDpdkDevice)

--- a/elements/userlevel/fromdpdkdevice.hh
+++ b/elements/userlevel/fromdpdkdevice.hh
@@ -1,0 +1,113 @@
+#ifndef CLICK_FROMDPDKDEVICE_HH
+#define CLICK_FROMDPDKDEVICE_HH
+
+#include <click/element.hh>
+#include <click/notifier.hh>
+#include <click/task.hh>
+#include <click/dpdkdevice.hh>
+
+CLICK_DECLS
+
+/*
+=title FromDpdkDevice
+
+=c
+
+FromDpdkDevice(PORT [, QUEUE, PROMISC, BURST, NDESC])
+
+=s netdevices
+
+reads packets from network device using Intel's DPDK (user-level)
+
+=d
+
+Reads packets from the network device with DPDK port identifier PORT.
+
+On the contrary to FromDevice.u which acts as a sniffer by default, packets
+received by devices put in DPDK mode will NOT be received by the kernel, and
+will thus be processed only once.
+
+Arguments:
+
+=over 8
+
+=item PORT
+
+Integer.  Port identifier of the device.
+
+=item QUEUE
+
+Integer.  Index of the queue to use. If omitted or negative, auto-increment
+between FromDpdkDevice attached to the same port will be used.
+
+=item PROMISC
+
+Boolean.  FromDpdkDevice puts the device in promiscuous mode if PROMISC is
+true. The default is false.
+
+=item BURST
+
+Integer.  Maximal number of packets that will be processed before rescheduling.
+The default is 32.
+
+=item NDESC
+
+Integer.  Number of descriptors per ring. The default is 256.
+
+=back
+
+This element is only available at user level, when compiled with DPDK
+support.
+
+=e
+
+  FromDpdkDevice(3, QUEUE 1) -> ...
+
+=h count read-only
+
+Returns the number of packets read by the device.
+
+=h reset_count write-only
+
+Resets "count" to zero.
+
+=a DpdkInfo, ToDpdkDevice */
+
+class FromDpdkDevice : public Element {
+public:
+
+    FromDpdkDevice() CLICK_COLD;
+    ~FromDpdkDevice() CLICK_COLD;
+
+    const char *class_name() const { return "FromDpdkDevice"; }
+    const char *port_count() const { return PORTS_0_1; }
+    const char *processing() const { return PUSH; }
+    int configure_phase() const {
+        return CONFIGURE_PHASE_PRIVILEGED;
+    }
+    bool can_live_reconfigure() const { return false; }
+
+    int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
+    int initialize(ErrorHandler *) CLICK_COLD;
+    void add_handlers() CLICK_COLD;
+    void cleanup(CleanupStage) CLICK_COLD;
+    bool run_task(Task *);
+
+private:
+
+    static String count_handler(Element*, void*) CLICK_COLD;
+    static int reset_count_handler(const String&, Element*, void*,
+                                   ErrorHandler*) CLICK_COLD;
+
+    unsigned int _port_id;
+    int _queue_id;
+    bool _promisc;
+    unsigned int _burst_size;
+    unsigned long _count;
+
+    Task _task;
+};
+
+CLICK_ENDDECLS
+
+#endif // CLICK_FROMDPDKDEVICE_HH

--- a/elements/userlevel/fromdpdkdevice.hh
+++ b/elements/userlevel/fromdpdkdevice.hh
@@ -9,11 +9,11 @@
 CLICK_DECLS
 
 /*
-=title FromDpdkDevice
+=title FromDPDKDevice
 
 =c
 
-FromDpdkDevice(PORT [, QUEUE, PROMISC, BURST, NDESC])
+FromDPDKDevice(PORT [, QUEUE [, I<keywords> PROMISC, BURST, NDESC]])
 
 =s netdevices
 
@@ -38,11 +38,11 @@ Integer.  Port identifier of the device.
 =item QUEUE
 
 Integer.  Index of the queue to use. If omitted or negative, auto-increment
-between FromDpdkDevice attached to the same port will be used.
+between FromDPDKDevice attached to the same port will be used.
 
 =item PROMISC
 
-Boolean.  FromDpdkDevice puts the device in promiscuous mode if PROMISC is
+Boolean.  FromDPDKDevice puts the device in promiscuous mode if PROMISC is
 true. The default is false.
 
 =item BURST
@@ -61,7 +61,7 @@ support.
 
 =e
 
-  FromDpdkDevice(3, QUEUE 1) -> ...
+  FromDPDKDevice(3, QUEUE 1) -> ...
 
 =h count read-only
 
@@ -71,15 +71,15 @@ Returns the number of packets read by the device.
 
 Resets "count" to zero.
 
-=a DpdkInfo, ToDpdkDevice */
+=a DPDKInfo, ToDPDKDevice */
 
-class FromDpdkDevice : public Element {
+class FromDPDKDevice : public Element {
 public:
 
-    FromDpdkDevice() CLICK_COLD;
-    ~FromDpdkDevice() CLICK_COLD;
+    FromDPDKDevice() CLICK_COLD;
+    ~FromDPDKDevice() CLICK_COLD;
 
-    const char *class_name() const { return "FromDpdkDevice"; }
+    const char *class_name() const { return "FromDPDKDevice"; }
     const char *port_count() const { return PORTS_0_1; }
     const char *processing() const { return PUSH; }
     int configure_phase() const {

--- a/elements/userlevel/todpdkdevice.cc
+++ b/elements/userlevel/todpdkdevice.cc
@@ -158,7 +158,7 @@ void ToDPDKDevice::flush_internal_queue(InternalQueue &iqueue) {
     _lock.acquire();
 
     do {
-        sub_burst = click_min(32, iqueue.nr_pending);
+        sub_burst = iqueue.nr_pending > 32 ? 32 : iqueue.nr_pending;
         if (iqueue.index + sub_burst >= _iqueue_size)
             // The sub_burst wraps around the ring
             sub_burst = _iqueue_size - iqueue.index;

--- a/elements/userlevel/todpdkdevice.cc
+++ b/elements/userlevel/todpdkdevice.cc
@@ -1,0 +1,234 @@
+/*
+ * todpdkdevice.{cc,hh} -- element sends packets to network via Intel's DPDK
+ *
+ * Copyright (c) 2014-2015 Cyril Soldani, University of Liège
+ * Copyright (c) 2015 Tom Barbette, University of Liège
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
+#include <click/config.h>
+
+#include <click/args.hh>
+#include <click/error.hh>
+#include <click/algorithm.hh>
+
+#include <rte_ethdev.h>
+#include <rte_mbuf.h>
+
+#include "todpdkdevice.hh"
+
+CLICK_DECLS
+
+ToDpdkDevice::ToDpdkDevice() :
+    _iqueues(), _port_id(0), _queue_id(0), _blocking(false),
+    _iqueue_size(1024), _burst_size(32), _timeout(0), _n_sent(0),
+    _n_dropped(0), _congestion_warning_printed(false)
+{
+}
+
+ToDpdkDevice::~ToDpdkDevice()
+{
+}
+
+int ToDpdkDevice::configure(Vector<String> &conf, ErrorHandler *errh)
+{
+    int n_desc;
+
+    if (Args(conf, this, errh)
+        .read_mp("PORT", _port_id)
+        .read_p("QUEUE", _queue_id)
+        .read_p("BLOCKING", _blocking)
+        .read_p("IQUEUE", _iqueue_size)
+        .read_p("BURST", _burst_size)
+        .read_p("TIMEOUT", _timeout)
+        .read("NDESC",n_desc)
+        .complete() < 0)
+        return -1;
+
+    if (_iqueue_size < _burst_size) {
+        _iqueue_size = _burst_size;
+        click_chatter(
+            "%s: IQUEUE cannot be smaller than BURST, IQUEUE has been set to "
+            "match BURST, that is %d", name().c_str(), _iqueue_size);
+    }
+
+    return DpdkDevice::add_tx_device(
+        _port_id, _queue_id, (n_desc > 0) ? n_desc : 1024, errh);
+}
+
+int ToDpdkDevice::initialize(ErrorHandler *errh)
+{
+    _iqueues.resize(click_max_cpu_ids());
+
+    for (int i = 0; i < _iqueues.size(); i++) {
+        _iqueues[i].pkts = new struct rte_mbuf *[_iqueue_size];
+        if (_timeout >= 0) {
+            _iqueues[i].timeout.assign(this);
+            _iqueues[i].timeout.initialize(this);
+        }
+    }
+
+    return DpdkDevice::initialize(errh);
+}
+
+void ToDpdkDevice::cleanup(CleanupStage)
+{
+    for (int i = 0; i < _iqueues.size(); i++)
+        delete[] _iqueues[i].pkts;
+}
+
+String ToDpdkDevice::n_sent_handler(Element *e, void *)
+{
+    ToDpdkDevice *tdd = static_cast<ToDpdkDevice *>(e);
+    return String(tdd->_n_sent);
+}
+
+String ToDpdkDevice::n_dropped_handler(Element *e, void *)
+{
+    ToDpdkDevice *tdd = static_cast<ToDpdkDevice *>(e);
+    return String(tdd->_n_dropped);
+}
+
+int ToDpdkDevice::reset_counts_handler(const String &, Element *e, void *,
+                                       ErrorHandler *)
+{
+    ToDpdkDevice *tdd = static_cast<ToDpdkDevice *>(e);
+    tdd->_n_sent = 0;
+    tdd->_n_dropped = 0;
+    return 0;
+}
+
+void ToDpdkDevice::add_handlers()
+{
+    add_read_handler("n_sent", n_sent_handler, 0);
+    add_read_handler("n_dropped", n_dropped_handler, 0);
+    add_write_handler("reset_counts", reset_counts_handler, 0,
+                      Handler::BUTTON);
+}
+
+/* Return the rte_mbuf pointer for a packet. If the buffer of the packet is
+ * from a DPDK pool, it will return the underlying rte_mbuf and remove the
+ * destructor. If it's a Click buffer, it will allocate a DPDK mbuf and copy
+ * the packet content to it if create is true. */
+inline struct rte_mbuf* get_mbuf(Packet* p, bool create=true) {
+    struct rte_mbuf* mbuf = 0;
+
+    if (likely(DpdkDevice::is_dpdk_packet(p))) {
+        mbuf = (struct rte_mbuf *) p->destructor_argument();
+        p->set_buffer_destructor(DpdkDevice::fake_free_pkt);
+    } else if (create) {
+        mbuf = rte_pktmbuf_alloc(DpdkDevice::get_mpool(rte_socket_id()));
+        memcpy((void*) rte_pktmbuf_mtod(mbuf, unsigned char *), p->data(),
+               p->length());
+        rte_pktmbuf_pkt_len(mbuf) = p->length();
+        rte_pktmbuf_data_len(mbuf) = p->length();
+    }
+
+    return mbuf;
+}
+
+void ToDpdkDevice::run_timer(Timer *)
+{
+    flush_internal_queue(_iqueues[click_current_cpu_id()]);
+}
+
+/* Flush as much as possible packets from a given internal queue to the DPDK
+ * device. */
+void ToDpdkDevice::flush_internal_queue(InternalQueue &iqueue) {
+    unsigned sent = 0;
+    unsigned r;
+    /* sub_burst is the number of packets DPDK should send in one call if
+     * there is no congestion, normally 32. If it sends less, it means
+     * there is no more room in the output ring and we'll need to come
+     * back later. Also, if we're wrapping around the ring, sub_burst
+     * will be used to split the burst in two, as rte_eth_tx_burst needs a
+     * contiguous buffer space.
+     */
+    unsigned sub_burst;
+
+    _lock.acquire();
+
+    do {
+        sub_burst = click_min(32, iqueue.nr_pending);
+        if (iqueue.index + sub_burst >= _iqueue_size)
+            // The sub_burst wraps around the ring
+            sub_burst = _iqueue_size - iqueue.index;
+        r = rte_eth_tx_burst(_port_id, _queue_id, &iqueue.pkts[iqueue.index],
+                             iqueue.nr_pending);
+
+        iqueue.nr_pending -= r;
+        iqueue.index += r;
+
+        if (iqueue.index >= _iqueue_size) // Wrapping around the ring
+            iqueue.index = 0;
+
+        sent += r;
+    } while (r == sub_burst && iqueue.nr_pending > 0);
+
+    _n_sent += sent;
+
+    _lock.release();
+
+    // If ring is empty, reset the index to avoid wrap ups
+    if (iqueue.nr_pending == 0)
+        iqueue.index = 0;
+}
+
+void ToDpdkDevice::push(int, Packet *p)
+{
+    // Get the thread-local internal queue
+    InternalQueue &iqueue = _iqueues[click_current_cpu_id()];
+
+    bool congestioned;
+    do {
+        congestioned = false;
+
+        if (iqueue.nr_pending == _iqueue_size) { // Internal queue is full
+            /* We just set the congestion flag. If we're in blocking mode,
+             * we'll loop, else we'll drop this packet.*/
+            congestioned = true;
+            if (!_blocking) {
+                if (_n_dropped < 5)
+                    click_chatter("%s: packet dropped", name().c_str());
+                _n_dropped++;
+            } else {
+                if (!_congestion_warning_printed)
+                    click_chatter("%s: congestion warning", name().c_str());
+                _congestion_warning_printed = true;
+            }
+        } else { // If there is space in the iqueue just after index + left
+            iqueue.pkts[(iqueue.index + iqueue.nr_pending) % _iqueue_size] =
+                get_mbuf(p);
+            iqueue.nr_pending++;
+        }
+
+        if (iqueue.nr_pending >= _burst_size || congestioned) {
+            flush_internal_queue(iqueue);
+            if (_timeout && iqueue.nr_pending == 0)
+                iqueue.timeout.unschedule();
+        } else if (_timeout >= 0 && !iqueue.timeout.scheduled()) {
+            if (_timeout == 0)
+                iqueue.timeout.schedule_now();
+            else
+                iqueue.timeout.schedule_after_msec(_timeout);
+        }
+
+        // If we're in blocking mode, we loop until we can put p in the iqueue
+    } while (unlikely(_blocking && congestioned));
+
+    p->kill();
+}
+
+CLICK_ENDDECLS
+ELEMENT_REQUIRES(userlevel dpdk)
+EXPORT_ELEMENT(ToDpdkDevice)
+ELEMENT_MT_SAFE(ToDpdkDevice)

--- a/elements/userlevel/todpdkdevice.hh
+++ b/elements/userlevel/todpdkdevice.hh
@@ -1,0 +1,174 @@
+#ifndef CLICK_TODPDKDEVICE_USERLEVEL_HH
+#define CLICK_TODPDKDEVICE_USERLEVEL_HH
+
+#include <click/element.hh>
+#include <click/sync.hh>
+#include <click/timer.hh>
+#include <click/dpdkdevice.hh>
+
+CLICK_DECLS
+
+/*
+=title ToDpdkDevice
+
+=c
+
+ToDpdkDevice(PORT [, QUEUE, IQUEUE, BLOCKING, BURST, TIMEOUT, NDESC]])
+
+=s netdevices
+
+sends packets to network device using Intel's DPDK (user-level)
+
+=d
+
+Sends packets to a network device with DPDK port identifier PORT. As DPDK does
+not support polling, this element only supports PUSH. It will build a batch of
+packets inside an internal queue (limited to IQUEUE packets) until it reaches
+BURST packets, and then send the batch to DPDK. If the batch is not ready after
+TIMEOUT ms, it will flush the batch of packets even if it doesn't cointain
+BURST packets.
+
+Arguments:
+
+=over 8
+
+=item PORT
+
+Integer.  Port identifier of the device.
+
+=item QUEUE
+
+Integer.  Index of the queue to use. If omitted or negative, auto-increment
+between ToDpdkDevice attached to the same port will be used.
+
+=item IQUEUE
+
+Integer.  Size of the internal queue, i.e. number of packets that we can buffer
+before pushing them to the DPDK framework. If IQUEUE is bigger than BURST,
+some packets could be buffered in the internal queue when the output ring is
+full. Defaults to 1024.
+
+=item BLOCKING
+
+Boolean.  If true, when there is no more space in the output device ring, and
+the IQUEUE is full, we'll block until some packet could be sent. If false the
+packet will be dropped. Defaults to true.
+
+=item BURST
+
+Integer.  Number of packets to batch before sending them out. A bigger BURST
+leads to more latency, but a better throughput. The default value of 32 is
+recommended as it is what DPDK will do under the hood. Prefer to set the
+TIMEOUT parameter to 0 if the throughput is low as it will maintain
+performance.
+
+=item TIMEOUT
+
+Integer.  Set a timeout to flush the internal queue. It is useful under low
+throughput as it could take a long time before reaching BURST packet in the
+internal queue. The timeout is expressed in milliseconds. Setting the timer to
+0 is not a bad idea as it will schedule after the source element (such as a
+FromDpdkDevice) will have finished its burst, or all incoming packets. This
+would therefore ensure that a flush is done right after all packets have been
+processed by the Click pipeline. Setting a negative value disable the timer,
+this is generally acceptable if the thoughput of this element rarely drops
+below 32000 pps (~50 Mbps with maximal size packets) with a BURST of 32, as the
+internal queue will wait on average 1 ms before containing 32 packets. Defaults
+to 0 (immediate flush).
+
+=item NDESC
+
+Integer.  Number of descriptors per ring. The default is 1024.
+
+=back
+
+This element is only available at user level, when compiled with DPDK support.
+
+=e
+
+  ... -> ToDpdkDevice(2, QUEUE 0)
+
+=h n_sent read-only
+
+Returns the number of packets sent by the device.
+
+=h n_dropped read-only
+
+Returns the number of packets dropped by the device.
+
+=h reset_counts write-only
+
+Resets n_send and n_dropped counts to zero.
+
+=a DpdkInfo, FromDpdkDevice */
+
+class ToDpdkDevice : public Element {
+public:
+
+    ToDpdkDevice() CLICK_COLD;
+    ~ToDpdkDevice() CLICK_COLD;
+
+    const char *class_name() const { return "ToDpdkDevice"; }
+    const char *port_count() const { return PORTS_1_0; }
+    const char *processing() const { return PUSH; }
+    int configure_phase() const {
+        return CONFIGURE_PHASE_PRIVILEGED;
+    }
+    bool can_live_reconfigure() const { return false; }
+
+    int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
+    int initialize(ErrorHandler *) CLICK_COLD;
+
+    void cleanup(CleanupStage stage) CLICK_COLD;
+
+    void add_handlers() CLICK_COLD;
+
+    void run_timer(Timer *);
+    void push(int port, Packet *p);
+
+private:
+
+    /* InternalQueue is a ring of DPDK buffers pointers (rte_mbuf *) awaiting
+     * to be sent.
+     * index is the index of the first valid packets awaiting to be sent, while
+     * nr_pending is the number of packets. index + nr_pending may be greater
+     * than _iqueue_size but index should be wrapped-around. */
+    class InternalQueue {
+    public:
+        InternalQueue() : pkts(0), index(0), nr_pending(0) { }
+
+        // Array of DPDK Buffers
+        struct rte_mbuf ** pkts;
+        // Index of the first valid packet in the pkts array
+        unsigned int index;
+        // Number of valid packets awaiting to be sent after index
+        unsigned int nr_pending;
+
+        // Timer to limit time a batch will take to be completed
+        Timer timeout;
+    } __attribute__((aligned(64)));
+
+    static String n_sent_handler(Element *, void *) CLICK_COLD;
+    static String n_dropped_handler(Element *, void *) CLICK_COLD;
+    static int reset_counts_handler(const String &, Element *, void *,
+                                    ErrorHandler *) CLICK_COLD;
+
+    void flush_internal_queue(InternalQueue &);
+
+    Vector<InternalQueue> _iqueues;
+
+    unsigned int _port_id;
+    int _queue_id;
+    bool _blocking;
+    Spinlock _lock;
+    unsigned int _iqueue_size;
+    unsigned int _burst_size;
+    int _timeout;
+    unsigned long _n_sent;
+    unsigned long _n_dropped;
+    bool _congestion_warning_printed;
+};
+
+CLICK_ENDDECLS
+
+#endif

--- a/elements/userlevel/todpdkdevice.hh
+++ b/elements/userlevel/todpdkdevice.hh
@@ -9,11 +9,11 @@
 CLICK_DECLS
 
 /*
-=title ToDpdkDevice
+=title ToDPDKDevice
 
 =c
 
-ToDpdkDevice(PORT [, QUEUE, IQUEUE, BLOCKING, BURST, TIMEOUT, NDESC]])
+ToDPDKDevice(PORT [, QUEUE [, I<keywords> IQUEUE, BLOCKING, etc.]])
 
 =s netdevices
 
@@ -39,7 +39,7 @@ Integer.  Port identifier of the device.
 =item QUEUE
 
 Integer.  Index of the queue to use. If omitted or negative, auto-increment
-between ToDpdkDevice attached to the same port will be used.
+between ToDPDKDevice attached to the same port will be used.
 
 =item IQUEUE
 
@@ -68,7 +68,7 @@ Integer.  Set a timeout to flush the internal queue. It is useful under low
 throughput as it could take a long time before reaching BURST packet in the
 internal queue. The timeout is expressed in milliseconds. Setting the timer to
 0 is not a bad idea as it will schedule after the source element (such as a
-FromDpdkDevice) will have finished its burst, or all incoming packets. This
+FromDPDKDevice) will have finished its burst, or all incoming packets. This
 would therefore ensure that a flush is done right after all packets have been
 processed by the Click pipeline. Setting a negative value disable the timer,
 this is generally acceptable if the thoughput of this element rarely drops
@@ -86,7 +86,7 @@ This element is only available at user level, when compiled with DPDK support.
 
 =e
 
-  ... -> ToDpdkDevice(2, QUEUE 0)
+  ... -> ToDPDKDevice(2, QUEUE 0, BLOCKING true)
 
 =h n_sent read-only
 
@@ -100,15 +100,15 @@ Returns the number of packets dropped by the device.
 
 Resets n_send and n_dropped counts to zero.
 
-=a DpdkInfo, FromDpdkDevice */
+=a DPDKInfo, FromDPDKDevice */
 
-class ToDpdkDevice : public Element {
+class ToDPDKDevice : public Element {
 public:
 
-    ToDpdkDevice() CLICK_COLD;
-    ~ToDpdkDevice() CLICK_COLD;
+    ToDPDKDevice() CLICK_COLD;
+    ~ToDPDKDevice() CLICK_COLD;
 
-    const char *class_name() const { return "ToDpdkDevice"; }
+    const char *class_name() const { return "ToDPDKDevice"; }
     const char *port_count() const { return PORTS_1_0; }
     const char *processing() const { return PUSH; }
     int configure_phase() const {

--- a/include/click/algorithm.hh
+++ b/include/click/algorithm.hh
@@ -90,8 +90,5 @@ struct less {
     }
 };
 
-#define click_min(a, b) ((a) < (b) ? (a) : (b))
-#define click_max(a, b) ((a) > (b) ? (a) : (b))
-
 CLICK_ENDDECLS
 #endif

--- a/include/click/algorithm.hh
+++ b/include/click/algorithm.hh
@@ -90,5 +90,8 @@ struct less {
     }
 };
 
+#define click_min(a, b) ((a) < (b) ? (a) : (b))
+#define click_max(a, b) ((a) > (b) ? (a) : (b))
+
 CLICK_ENDDECLS
 #endif

--- a/include/click/dpdkdevice.hh
+++ b/include/click/dpdkdevice.hh
@@ -7,7 +7,7 @@
 
 CLICK_DECLS
 
-class DpdkDevice {
+class DPDKDevice {
 public:
 
     static struct rte_mempool *get_mpool(unsigned int);
@@ -22,7 +22,7 @@ public:
     static int initialize(ErrorHandler *errh);
 
     inline static bool is_dpdk_packet(Packet* p) {
-            return p->buffer_destructor() == DpdkDevice::free_pkt;
+            return p->buffer_destructor() == DPDKDevice::free_pkt;
     }
 
     static void free_pkt(unsigned char *, size_t, void *pktmbuf);
@@ -49,13 +49,13 @@ private:
         inline DevInfo() :
             n_rx_queues(0), n_tx_queues(0), promisc(false), n_rx_descs(0),
             n_tx_descs(0) {}
-        inline DevInfo(DpdkDevice::Dir dir, unsigned queue_id, bool promisc,
+        inline DevInfo(DPDKDevice::Dir dir, unsigned queue_id, bool promisc,
                        unsigned n_desc) :
-            n_rx_queues((dir == DpdkDevice::RX) ? queue_id + 1 : 0),
-            n_tx_queues((dir == DpdkDevice::TX) ? queue_id + 1 : 0),
+            n_rx_queues((dir == DPDKDevice::RX) ? queue_id + 1 : 0),
+            n_tx_queues((dir == DPDKDevice::TX) ? queue_id + 1 : 0),
             promisc(promisc),
-            n_rx_descs((dir == DpdkDevice::RX) ? n_desc : 256),
-            n_tx_descs((dir == DpdkDevice::TX) ? n_desc : 1024)
+            n_rx_descs((dir == DPDKDevice::RX) ? n_desc : 256),
+            n_tx_descs((dir == DPDKDevice::TX) ? n_desc : 1024)
             {}
 
         unsigned n_rx_queues;

--- a/include/click/dpdkdevice.hh
+++ b/include/click/dpdkdevice.hh
@@ -1,0 +1,84 @@
+#ifndef CLICK_DPDKDEVICE_HH
+#define CLICK_DPDKDEVICE_HH
+
+#include <click/packet.hh>
+#include <click/error.hh>
+#include <click/hashmap.hh>
+
+CLICK_DECLS
+
+class DpdkDevice {
+public:
+
+    static struct rte_mempool *get_mpool(unsigned int);
+
+    static int get_port_numa_node(unsigned port_id);
+
+    static int add_rx_device(unsigned port_id, int &queue_id, bool promisc,
+                             unsigned n_desc, ErrorHandler *errh);
+
+    static int add_tx_device(unsigned port_id, int &queue_id, unsigned n_desc,
+                             ErrorHandler *errh);
+    static int initialize(ErrorHandler *errh);
+
+    inline static bool is_dpdk_packet(Packet* p) {
+            return p->buffer_destructor() == DpdkDevice::free_pkt;
+    }
+
+    static void free_pkt(unsigned char *, size_t, void *pktmbuf);
+
+    static void fake_free_pkt(unsigned char *, size_t, void *pktmbuf);
+
+    static unsigned int get_nb_txdesc(unsigned port_id);
+
+    static int NB_MBUF;
+    static int MBUF_SIZE;
+    static int MBUF_CACHE_SIZE;
+    static int RX_PTHRESH;
+    static int RX_HTHRESH;
+    static int RX_WTHRESH;
+    static int TX_PTHRESH;
+    static int TX_HTHRESH;
+    static int TX_WTHRESH;
+
+private:
+
+    enum Dir { RX, TX };
+
+    struct DevInfo {
+        inline DevInfo() :
+            n_rx_queues(0), n_tx_queues(0), promisc(false), n_rx_descs(0),
+            n_tx_descs(0) {}
+        inline DevInfo(DpdkDevice::Dir dir, unsigned queue_id, bool promisc,
+                       unsigned n_desc) :
+            n_rx_queues((dir == DpdkDevice::RX) ? queue_id + 1 : 0),
+            n_tx_queues((dir == DpdkDevice::TX) ? queue_id + 1 : 0),
+            promisc(promisc),
+            n_rx_descs((dir == DpdkDevice::RX) ? n_desc : 256),
+            n_tx_descs((dir == DpdkDevice::TX) ? n_desc : 1024)
+            {}
+
+        unsigned n_rx_queues;
+        unsigned n_tx_queues;
+        bool promisc;
+        unsigned n_rx_descs;
+        unsigned n_tx_descs;
+    };
+
+    static bool _is_initialized;
+    static HashMap<unsigned, DevInfo> _devs;
+    static struct rte_mempool** _pktmbuf_pools;
+
+    static int initialize_device(unsigned port_id, const DevInfo &info,
+                                 ErrorHandler *errh) CLICK_COLD;
+
+    static bool alloc_pktmbufs() CLICK_COLD;
+
+    static int add_device(unsigned port_id, Dir dir, int &queue_id,
+                          bool promisc, unsigned n_desc, ErrorHandler *errh)
+        CLICK_COLD;
+};
+
+CLICK_ENDDECLS
+
+#endif

--- a/include/click/packet.hh
+++ b/include/click/packet.hh
@@ -97,6 +97,15 @@ class Packet { public:
     buffer_destructor_type buffer_destructor() const {
 	return _destructor;
     }
+
+    void set_buffer_destructor(buffer_destructor_type destructor) {
+        _destructor = destructor;
+    }
+
+    void* destructor_argument() {
+        return _destructor_argument;
+    }
+
     void reset_buffer() {
 	assert(!shared());
 	_head = _data = _tail = _end = 0;

--- a/lib/dpdkdevice.cc
+++ b/lib/dpdkdevice.cc
@@ -1,0 +1,277 @@
+/*
+ * dpdkdevice.{cc,hh} -- library for interfacing with Intel's DPDK
+ *
+ * Copyright (c) 2014-2015 Cyril Soldani, University of Liège
+ * Copyright (c) 2015 Tom Barbette, University of Liège
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
+#include <click/config.h>
+#include <click/dpdkdevice.hh>
+
+#include <rte_common.h>
+#include <rte_eal.h>
+#include <rte_ethdev.h>
+#include <rte_lcore.h>
+#include <rte_mbuf.h>
+#include <rte_mempool.h>
+#include <rte_pci.h>
+#include <rte_version.h>
+
+
+CLICK_DECLS
+
+/* Wraps rte_eth_dev_socket_id(), which may return -1 for valid ports when NUMA
+ * is not well supported. This function will return 0 instead in that case. */
+int DpdkDevice::get_port_numa_node(unsigned port_id)
+{
+    if (port_id >= rte_eth_dev_count())
+        return -1;
+    int numa_node = rte_eth_dev_socket_id(port_id);
+    return (numa_node == -1) ? 0 : numa_node;
+}
+
+unsigned int DpdkDevice::get_nb_txdesc(unsigned port_id)
+{
+    DevInfo *info = _devs.findp(port_id);
+    if (!info)
+        return 0;
+
+    return info->n_tx_descs;
+}
+
+bool DpdkDevice::alloc_pktmbufs()
+{
+    // Count NUMA sockets
+    int max_socket = -1;
+    for (HashMap<unsigned, DevInfo>::const_iterator it = _devs.begin();
+         it != _devs.end(); ++it) {
+        int numa_node = DpdkDevice::get_port_numa_node(it.key());
+        if (numa_node > max_socket)
+            max_socket = numa_node;
+    }
+    if (max_socket == -1)
+        return false;
+
+    // Allocate pktmbuf_pool array
+    typedef struct rte_mempool *rte_mempool_p;
+    _pktmbuf_pools = new rte_mempool_p[max_socket + 1];
+    if (!_pktmbuf_pools)
+        return false;
+    memset(_pktmbuf_pools, 0, (max_socket + 1) * sizeof(rte_mempool_p));
+
+    // Create a pktmbuf pool for each active socket
+    for (HashMap<unsigned, DevInfo>::const_iterator it = _devs.begin();
+         it != _devs.end(); ++it) {
+        int numa_node = DpdkDevice::get_port_numa_node(it.key());
+        if (!_pktmbuf_pools[numa_node]) {
+            char name[64];
+            snprintf(name, 64, "mbuf_pool_%u", numa_node);
+            _pktmbuf_pools[numa_node] =
+                rte_mempool_create(
+                    name, NB_MBUF, MBUF_SIZE, MBUF_CACHE_SIZE,
+                    sizeof (struct rte_pktmbuf_pool_private),
+                    rte_pktmbuf_pool_init, NULL, rte_pktmbuf_init, NULL,
+                    numa_node, 0);
+            if (!_pktmbuf_pools[numa_node])
+                return false;
+        }
+    }
+
+    return true;
+}
+
+struct rte_mempool *DpdkDevice::get_mpool(unsigned int socket_id) {
+    return _pktmbuf_pools[socket_id];
+}
+
+int DpdkDevice::initialize_device(unsigned port_id, const DevInfo &info,
+                                  ErrorHandler *errh)
+{
+    struct rte_eth_conf dev_conf;
+    struct rte_eth_dev_info dev_info;
+    memset(&dev_conf, 0, sizeof dev_conf);
+
+    rte_eth_dev_info_get(port_id, &dev_info);
+
+    dev_conf.rxmode.mq_mode = ETH_MQ_RX_RSS;
+    dev_conf.rx_adv_conf.rss_conf.rss_key = NULL;
+    dev_conf.rx_adv_conf.rss_conf.rss_hf = ETH_RSS_IP;
+
+    if (rte_eth_dev_configure(port_id, info.n_rx_queues, info.n_tx_queues,
+                              &dev_conf) < 0)
+        return errh->error(
+            "Cannot initialize DPDK port %u with %u RX and %u TX queues",
+            port_id, info.n_rx_queues, info.n_tx_queues);
+    struct rte_eth_rxconf rx_conf;
+#if RTE_VER_MAJOR >= 2
+    memcpy(&rx_conf, &dev_info.default_rxconf, sizeof rx_conf);
+#else
+    bzero(&rx_conf,sizeof rx_conf);
+#endif
+    rx_conf.rx_thresh.pthresh = RX_PTHRESH;
+    rx_conf.rx_thresh.hthresh = RX_HTHRESH;
+    rx_conf.rx_thresh.wthresh = RX_WTHRESH;
+
+    struct rte_eth_txconf tx_conf;
+#if RTE_VER_MAJOR >= 2
+    memcpy(&tx_conf, &dev_info.default_txconf, sizeof tx_conf);
+#else
+    bzero(&tx_conf,sizeof tx_conf);
+#endif
+    tx_conf.tx_thresh.pthresh = TX_PTHRESH;
+    tx_conf.tx_thresh.hthresh = TX_HTHRESH;
+    tx_conf.tx_thresh.wthresh = TX_WTHRESH;
+    tx_conf.txq_flags |= ETH_TXQ_FLAGS_NOMULTSEGS | ETH_TXQ_FLAGS_NOOFFLOADS;
+
+    int numa_node = DpdkDevice::get_port_numa_node(port_id);
+    for (unsigned i = 0; i < info.n_rx_queues; ++i) {
+        if (rte_eth_rx_queue_setup(
+                port_id, i, info.n_rx_descs, numa_node, &rx_conf,
+                _pktmbuf_pools[numa_node]) != 0)
+            return errh->error(
+                "Cannot initialize RX queue %u of port %u on node %u",
+                i, port_id, numa_node);
+    }
+
+    for (unsigned i = 0; i < info.n_tx_queues; ++i)
+        if (rte_eth_tx_queue_setup(port_id, i, info.n_tx_descs, numa_node,
+                                   &tx_conf) != 0)
+            return errh->error(
+                "Cannot initialize TX queue %u of port %u on node %u",
+                i, port_id, numa_node);
+
+    int err = rte_eth_dev_start(port_id);
+    if (err < 0)
+        return errh->error(
+            "Cannot start DPDK port %u: error %d", port_id, err);
+
+    if (info.promisc)
+        rte_eth_promiscuous_enable(port_id);
+
+    return 0;
+}
+
+int DpdkDevice::add_device(unsigned port_id, DpdkDevice::Dir dir,
+                           int &queue_id, bool promisc, unsigned n_desc,
+                           ErrorHandler *errh)
+{
+    if (_is_initialized)
+        return errh->error(
+            "Trying to configure DPDK device after initialization");
+
+    DevInfo *info = _devs.findp(port_id);
+    if (!info) {
+        DevInfo info(dir, (queue_id < 0) ? 0 : queue_id, promisc, n_desc);
+        _devs.insert(port_id, info);
+    } else {
+        if (dir == RX) {
+            if (info->n_rx_queues > 0 && promisc != info->promisc)
+                return errh->error(
+                    "Some elements disagree on whether or not device %u should"
+                    " be in promiscuous mode", port_id);
+            info->promisc |= promisc;
+            if (n_desc != info->n_rx_descs)
+                return errh->error(
+                    "Some elements disagree on the number of RX descriptors "
+                    "for device %u", port_id);
+            info->n_rx_queues =
+                1 + ((queue_id <= 0) ? info->n_rx_queues : queue_id);
+        } else {
+            if (n_desc != info->n_tx_descs)
+                return errh->error(
+                    "Some elements disagree on the number of TX descriptors "
+                    "for device %u", port_id);
+            info->n_tx_queues =
+                1 + ((queue_id <= 0) ? info->n_tx_queues : queue_id);
+        }
+    }
+
+    return 0;
+}
+
+int DpdkDevice::add_rx_device(unsigned port_id, int &queue_id, bool promisc,
+                              unsigned n_desc, ErrorHandler *errh)
+{
+    return add_device(
+        port_id, DpdkDevice::RX, queue_id, promisc, n_desc, errh);
+}
+
+int DpdkDevice::add_tx_device(unsigned port_id, int &queue_id, unsigned n_desc,
+                              ErrorHandler *errh)
+{
+    return add_device(port_id, DpdkDevice::TX, queue_id, false, n_desc, errh);
+}
+
+int DpdkDevice::initialize(ErrorHandler *errh)
+{
+    if (_is_initialized)
+        return 0;
+
+    click_chatter("Initializing DPDK");
+#if RTE_VER_MAJOR < 2
+    if (rte_eal_pci_probe())
+        return errh->error("Cannot probe the PCI bus");
+#endif
+
+    // We should maybe do PCI probing and get some stats when DpdkConfig loads
+    // so that we can check the following at configure time rather than during
+    // initialization
+
+    const unsigned n_ports = rte_eth_dev_count();
+    if (n_ports == 0)
+        return errh->error("No DPDK-enabled ethernet port found");
+
+    for (HashMap<unsigned, DevInfo>::const_iterator it = _devs.begin();
+         it != _devs.end(); ++it)
+        if (it.key() >= n_ports)
+            return errh->error("Cannot find DPDK port %u", it.key());
+
+    if (!alloc_pktmbufs())
+        return errh->error("Could not allocate packet MBuf pools");
+
+    for (HashMap<unsigned, DevInfo>::const_iterator it = _devs.begin();
+         it != _devs.end(); ++it) {
+        int ret = initialize_device(it.key(), it.value(), errh);
+        if (ret < 0)
+            return ret;
+    }
+
+    _is_initialized = true;
+    return 0;
+}
+
+void DpdkDevice::free_pkt(unsigned char *, size_t, void *pktmbuf)
+{
+    rte_pktmbuf_free((struct rte_mbuf *) pktmbuf);
+}
+
+void DpdkDevice::fake_free_pkt(unsigned char *, size_t, void *)
+{
+}
+
+int DpdkDevice::NB_MBUF = 65536*8;
+int DpdkDevice::MBUF_SIZE =
+    2048 + sizeof (struct rte_mbuf) + RTE_PKTMBUF_HEADROOM;
+int DpdkDevice::MBUF_CACHE_SIZE = 256;
+int DpdkDevice::RX_PTHRESH = 8;
+int DpdkDevice::RX_HTHRESH = 8;
+int DpdkDevice::RX_WTHRESH = 4;
+int DpdkDevice::TX_PTHRESH = 36;
+int DpdkDevice::TX_HTHRESH = 0;
+int DpdkDevice::TX_WTHRESH = 0;
+
+bool DpdkDevice::_is_initialized = false;
+HashMap<unsigned, DpdkDevice::DevInfo> DpdkDevice::_devs;
+struct rte_mempool** DpdkDevice::_pktmbuf_pools;
+
+CLICK_ENDDECLS

--- a/userlevel/Makefile.in
+++ b/userlevel/Makefile.in
@@ -101,9 +101,11 @@ CCLD = $(CC)
 LINK = $(CCLD) $(CFLAGS) $(LDFLAGS) -o $@
 
 USE_DPDK = @USE_DPDK@
+ifeq ($(USE_DPDK),yes)
+RTE_SDK = @RTE_SDK@
+RTE_TARGET = @RTE_TARGET@
 RTE_VER_MAJOR = @RTE_VER_MAJOR@
 RTE_VER_MINOR = @RTE_VER_MINOR@
-ifeq ($(USE_DPDK),yes)
 include dpdk.mk
 EXTRA_DRIVER_OBJS := dpdkdevice.o $(EXTRA_DRIVER_OBJS)
 endif

--- a/userlevel/Makefile.in
+++ b/userlevel/Makefile.in
@@ -100,6 +100,14 @@ COMPILE = $(CC) $(DEFS) $(INCLUDES) $(CPPFLAGS) $(CFLAGS)
 CCLD = $(CC)
 LINK = $(CCLD) $(CFLAGS) $(LDFLAGS) -o $@
 
+USE_DPDK = @USE_DPDK@
+RTE_VER_MAJOR = @RTE_VER_MAJOR@
+RTE_VER_MINOR = @RTE_VER_MINOR@
+ifeq ($(USE_DPDK),yes)
+include dpdk.mk
+EXTRA_DRIVER_OBJS := dpdkdevice.o $(EXTRA_DRIVER_OBJS)
+endif
+
 ifndef MINDRIVER
 DRIVER = click
 ELEMENTSCONF = elements

--- a/userlevel/dpdk.mk
+++ b/userlevel/dpdk.mk
@@ -1,0 +1,197 @@
+ifeq ($(RTE_SDK),)
+$(error "Please define RTE_SDK environment variable")
+endif
+ifeq ($(RTE_TARGET),)
+$(error "Please define RTE_TARGET environment variable")
+endif
+
+# Save C flags
+DPDK_OLD_CFLAGS := $(CFLAGS)
+
+include $(RTE_SDK)/mk/rte.vars.mk
+
+LIBS += -L$(RTE_SDK_BIN)/lib
+
+# Include libraries depending on config if NO_AUTOLIBS is not set
+# Order is important: from higher level to lower level
+
+ifeq ($(NO_AUTOLIBS),)
+
+LIBS += -Wl,--whole-archive
+
+ifeq ($(CONFIG_RTE_LIBRTE_DISTRIBUTOR),y)
+LIBS += -lrte_distributor
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_KNI),y)
+ifeq ($(CONFIG_RTE_EXEC_ENV_LINUXAPP),y)
+LIBS += -lrte_kni
+endif
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_IVSHMEM),y)
+ifeq ($(CONFIG_RTE_EXEC_ENV_LINUXAPP),y)
+LIBS += -lrte_ivshmem
+endif
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_PIPELINE),y)
+LIBS += -lrte_pipeline
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_TABLE),y)
+LIBS += -lrte_table
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_PORT),y)
+LIBS += -lrte_port
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_TIMER),y)
+LIBS += -lrte_timer
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_HASH),y)
+LIBS += -lrte_hash
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_LPM),y)
+LIBS += -lrte_lpm
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_POWER),y)
+LIBS += -lrte_power
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_ACL),y)
+LIBS += -lrte_acl
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_METER),y)
+LIBS += -lrte_meter
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_SCHED),y)
+LIBS += -lrte_sched
+LIBS += -lm
+LIBS += -lrt
+endif
+
+LIBS += -Wl,--start-group
+
+ifeq ($(CONFIG_RTE_LIBRTE_KVARGS),y)
+LIBS += -lrte_kvargs
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_MBUF),y)
+LIBS += -lrte_mbuf
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_IP_FRAG),y)
+LIBS += -lrte_ip_frag
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_ETHER),y)
+LIBS += -lethdev
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_MALLOC),y)
+LIBS += -lrte_malloc
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_MEMPOOL),y)
+LIBS += -lrte_mempool
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_RING),y)
+LIBS += -lrte_ring
+endif
+
+ifeq ($(CONFIG_RTE_LIBC),y)
+LIBS += -lc
+LIBS += -lm
+endif
+
+ifeq ($(CONFIG_RTE_LIBGLOSS),y)
+LIBS += -lgloss
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_EAL),y)
+LIBS += -lrte_eal
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_CMDLINE),y)
+LIBS += -lrte_cmdline
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_CFGFILE),y)
+LIBS += -lrte_cfgfile
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_PMD_BOND),y)
+LIBS += -lrte_pmd_bond
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_PMD_XENVIRT),y)
+LIBS += -lrte_pmd_xenvirt
+LIBS += -lxenstore
+endif
+
+ifeq ($(CONFIG_RTE_BUILD_SHARED_LIB),n)
+# Plugins (link only if static libraries)
+
+ifeq ($(CONFIG_RTE_LIBRTE_VMXNET3_PMD),y)
+LIBS += -lrte_pmd_vmxnet3_uio
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_VIRTIO_PMD),y)
+ifeq ($(shell [ $(RTE_VER_MAJOR) -ge 2 ] && echo true),true)
+  LIBS += -lrte_pmd_virtio
+else
+  LIBS += -lrte_pmd_virtio_uio
+endif
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_I40E_PMD),y)
+LIBS += -lrte_pmd_i40e
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_IXGBE_PMD),y)
+LIBS += -lrte_pmd_ixgbe
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_E1000_PMD),y)
+LIBS += -lrte_pmd_e1000
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_PMD_RING),y)
+LIBS += -lrte_pmd_ring
+endif
+
+ifeq ($(CONFIG_RTE_LIBRTE_PMD_PCAP),y)
+LIBS += -lrte_pmd_pcap -lpcap
+endif
+
+endif # Plugins
+
+LIBS += $(EXECENV_LDLIBS)
+
+LIBS += -Wl,--end-group
+
+LIBS += -Wl,--no-whole-archive
+
+endif # ifeq ($(NO_AUTOLIBS),)
+
+LIBS += $(CPU_LDLIBS)
+
+# Merge and rename flags
+CXXFLAGS := $(CXXFLAGS) $(CFLAGS) $(EXTRA_CFLAGS)
+
+include $(RTE_SDK)/mk/internal/rte.build-pre.mk
+
+LDFLAGS += $(EXTRA_LDFLAGS)
+
+override LDFLAGS := $(call linkerprefix,$(LDFLAGS))
+
+# Restore previous C flags
+CFLAGS := $(DPDK_OLD_CFLAGS)


### PR DESCRIPTION
Provide 3 new elements to use Intel's DPDK framework (compatible from
version 1.7 to the current 2.1) to receive and output packets at very
high speed in Click. Configure using the --enable-dpdk to enable the
DPDK framework. [1] provides a comparison of throughput using the new
DPDK implementation and the Netmap one with the best configuration
achievable in a forwarding (without touching the packet) and a router
configuration.

FromDpdkDevice is used to receive packets and ToDpdkDevice to output
packets. DpdkInfo can be used to set some DPDK-related parameters, see
[2] and dpdkinfo.hh for more informations about them.

These I/O elements supports multiqueue, you can use the QUEUE
parameter to specify a queue index. If omitted, one queue will be used
per FromDpdkDevice/ToDpdkDevice

Difference from traditional ToDevice is that ToDpdkDevice only
supports PUSH mode, as DPDK does not allow select-like mechanism.
Anyway [3] shows that full-push mode leads to better performance most
of the time. However, under very low throughput this could induce
higher latency as the output device waits for a certain number of
packets (BURST parameter) before flushing. The TIMEOUT parameter
allows you to limit that time.

ToDpdkDevice is thread-safe, by using a vector of internal queues to
batch packets, and one timer per thread. It uses a spinlock when the
batch is ready to protect the physical device. Regarding the
FromDpdkDevice, as only one thread will spawn the Task, it does not
need such a lock or per-thread state. This mechanism is by far faster
than using a ThreadSafeQueue or an external locking element.

This patch is a stripped version of the DPDK support in FastClick
(mostly without batching and auto-thread assignment). User may want to
read [3] for implementation detail, better queue/burst usage and read
further about full-push mode.

For archive, we also tried a DPDK-pool mode, where we don't use Click
Packet object but a wrapper around DPDK's mbuf. While this saves a
little memory, it was slower as Click's Packet object are re-used and
provide a better memory locality.
Indeed, putting anotations in DPDK's mbuf header lead to two cache
miss per header instead of zero when Click can cycle through Packet
object, just changing the buffer pointers and reusing them. If people
are interested in this, they can try it in the code of [3].

[1] http://bit.ly/1Z2Eg4W - Performance of this new DPDK implementation
[2] http://www.dpdk.org - DPDK website
[3] http://hdl.handle.net/2268/181954 - FastClick paper