### PR TITLE
EtherRewrite and SpinlockPush

### DIFF
--- a/elements/ethernet/ensureether.hh
+++ b/elements/ethernet/ensureether.hh
@@ -32,7 +32,7 @@ destination address 2:2:2:2:2:2:
 
 =a
 
-EnsureEther */
+EtherEncap, EtherRewrite */
 
 class EnsureEther : public Element { public:
 

--- a/elements/ethernet/ensureether.hh
+++ b/elements/ethernet/ensureether.hh
@@ -24,19 +24,15 @@ specified by the arguments is prepended to the packet.
 
 =e
 
-Encapsulate packets in an Ethernet header with type
+Encapsulate packets without an Ethernet header with type
 ETHERTYPE_IP (0x0800), source address 1:1:1:1:1:1, and
 destination address 2:2:2:2:2:2:
 
-  EtherEncap(0x0800, 1:1:1:1:1:1, 2:2:2:2:2:2)
-
-=n
-
-For IP packets you probably want to use ARPQuerier instead.
+  EnsureEther(0x0800, 1:1:1:1:1:1, 2:2:2:2:2:2)
 
 =a
 
-EtherEncap */
+EnsureEther */
 
 class EnsureEther : public Element { public:
 

--- a/elements/ethernet/etherencap.hh
+++ b/elements/ethernet/etherencap.hh
@@ -44,7 +44,7 @@ Return or set the ETHERTYPE parameter.
 
 =a
 
-EtherVLANEncap, ARPQuerier, EnsureEther, StoreEtherAddress */
+EtherVLANEncap, ARPQuerier, EnsureEther, StoreEtherAddress, EtherRewrite */
 
 class EtherEncap : public Element { public:
 

--- a/elements/ethernet/etherrewrite.cc
+++ b/elements/ethernet/etherrewrite.cc
@@ -1,0 +1,80 @@
+/*
+ * EtherRewrite.{cc,hh} -- encapsulates packet in Ethernet header
+ *
+ * Copyright (c) 2015 University of Liege
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
+#include <click/config.h>
+#include "etherrewrite.hh"
+#include <click/etheraddress.hh>
+#include <click/args.hh>
+#include <click/error.hh>
+#include <click/glue.hh>
+CLICK_DECLS
+
+EtherRewrite::EtherRewrite()
+{
+}
+
+EtherRewrite::~EtherRewrite()
+{
+}
+
+int
+EtherRewrite::configure(Vector<String> &conf, ErrorHandler *errh)
+{
+    uint16_t ether_type;
+    if (Args(conf, this, errh)
+	.read_mp("SRC", EtherAddressArg(), _ethh.ether_shost)
+	.read_mp("DST", EtherAddressArg(), _ethh.ether_dhost)
+	.complete() < 0)
+	return -1;
+    return 0;
+}
+
+inline Packet *
+EtherRewrite::smaction(Packet *p)
+{
+    WritablePacket* q = p->uniqueify();
+    if (q) {
+        memcpy(q->mac_header(), &_ethh, 12);
+    }
+    return q;
+}
+
+void
+EtherRewrite::push(int, Packet *p)
+{
+    output(0).push(smaction(p));
+}
+
+Packet *
+EtherRewrite::pull(int)
+{
+    if (Packet *p = input(0).pull())
+	return smaction(p);
+    else
+	return 0;
+}
+
+void
+EtherRewrite::add_handlers()
+{
+    add_data_handlers("src", Handler::h_read, reinterpret_cast<EtherAddress *>(&_ethh.ether_shost));
+    add_write_handler("src", reconfigure_keyword_handler, "1 SRC");
+    add_data_handlers("dst", Handler::h_read, reinterpret_cast<EtherAddress *>(&_ethh.ether_dhost));
+    add_write_handler("dst", reconfigure_keyword_handler, "2 DST");
+}
+
+CLICK_ENDDECLS
+EXPORT_ELEMENT(EtherRewrite)

--- a/elements/ethernet/etherrewrite.cc
+++ b/elements/ethernet/etherrewrite.cc
@@ -33,7 +33,6 @@ EtherRewrite::~EtherRewrite()
 int
 EtherRewrite::configure(Vector<String> &conf, ErrorHandler *errh)
 {
-    uint16_t ether_type;
     if (Args(conf, this, errh)
 	.read_mp("SRC", EtherAddressArg(), _ethh.ether_shost)
 	.read_mp("DST", EtherAddressArg(), _ethh.ether_dhost)
@@ -55,7 +54,8 @@ EtherRewrite::smaction(Packet *p)
 void
 EtherRewrite::push(int, Packet *p)
 {
-    output(0).push(smaction(p));
+    if (Packet *q = smaction(p))
+        output(0).push(q);
 }
 
 Packet *

--- a/elements/ethernet/etherrewrite.cc
+++ b/elements/ethernet/etherrewrite.cc
@@ -1,5 +1,6 @@
 /*
  * EtherRewrite.{cc,hh} -- encapsulates packet in Ethernet header
+ * Tom Barbette
  *
  * Copyright (c) 2015 University of Liege
  *

--- a/elements/ethernet/etherrewrite.hh
+++ b/elements/ethernet/etherrewrite.hh
@@ -1,0 +1,72 @@
+#ifndef CLICK_ETHERREWRITE_HH
+#define CLICK_ETHERREWRITE_HH
+#include <click/element.hh>
+#include <clicknet/ether.h>
+CLICK_DECLS
+
+/*
+=c
+
+EtherRewrite(SRC, DST)
+
+=s ethernet
+
+rewrite source and destination Ethernet address
+
+=d
+
+Rewrite the source and the destination address in the Ethernet header.
+The ETHERTYPE is left untouched.
+
+=e
+
+Ensure that source address of all packets passing by is 1:1:1:1:1:1, and
+the destination address is 2:2:2:2:2:2:
+
+  EtherRewrite(1:1:1:1:1:1, 2:2:2:2:2:2)
+
+=n
+
+This element is useful if there is only one possible nexthop on a given link
+(such as for a network-layer transparent firewall), meaning that source and
+destination ethernet address will always be the same for a given output.
+
+=h src read/write
+
+Return or set the SRC parameter.
+
+=h dst read/write
+
+Return or set the DST parameter.
+
+=a
+
+EtherEncap, EtherVLANEncap, ARPQuerier, EnsureEther, StoreEtherAddress */
+
+
+class EtherRewrite : public Element { public:
+
+    EtherRewrite() CLICK_COLD;
+    ~EtherRewrite() CLICK_COLD;
+
+    const char *class_name() const	{ return "EtherRewrite"; }
+    const char *port_count() const	{ return PORTS_1_1; }
+
+    int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
+    bool can_live_reconfigure() const	{ return true; }
+    void add_handlers() CLICK_COLD;
+
+    inline Packet *smaction(Packet *);
+
+    Packet *pull(int);
+
+    void push(int, Packet *);
+
+  private:
+
+    click_ether _ethh;
+
+};
+
+CLICK_ENDDECLS
+#endif

--- a/elements/threads/spinlockpush.cc
+++ b/elements/threads/spinlockpush.cc
@@ -1,0 +1,41 @@
+/*
+ * spinlockpush.{cc,hh} -- element acquires spinlock
+ * Benjie Chen, Eddie Kohler
+ *
+ * Copyright (c) 1999-2000 Massachusetts Institute of Technology.
+ * Copyright (c) 2008 Meraki, Inc.
+ * Copyright (c) 1999-2013 Eddie Kohler
+ * Copyright (c) 2015 Tom Barbette
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
+#include <click/config.h>
+#include <click/router.hh>
+#include <click/confparse.hh>
+#include <click/error.hh>
+#include <click/nameinfo.hh>
+#include "spinlockpush.hh"
+CLICK_DECLS
+
+int
+SpinlockPush::configure(Vector<String> &conf, ErrorHandler *errh)
+{
+    String name;
+    if (Args(conf, this, errh).read_mp("LOCK", name).complete() < 0)
+	return -1;
+    if (!NameInfo::query(NameInfo::T_SPINLOCK, this, name, &_lock, sizeof(Spinlock *)))
+	return errh->error("cannot locate spinlock %s", name.c_str());
+    return 0;
+}
+
+CLICK_ENDDECLS
+EXPORT_ELEMENT(SpinlockPush)

--- a/elements/threads/spinlockpush.cc
+++ b/elements/threads/spinlockpush.cc
@@ -1,11 +1,11 @@
 /*
  * spinlockpush.{cc,hh} -- element acquires spinlock
- * Benjie Chen, Eddie Kohler
+ * Benjie Chen, Eddie Kohler, Tom Barbette
  *
  * Copyright (c) 1999-2000 Massachusetts Institute of Technology.
  * Copyright (c) 2008 Meraki, Inc.
  * Copyright (c) 1999-2013 Eddie Kohler
- * Copyright (c) 2015 Tom Barbette
+ * Copyright (c) 2015 University of Liege
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/elements/threads/spinlockpush.hh
+++ b/elements/threads/spinlockpush.hh
@@ -1,0 +1,45 @@
+#ifndef CLICK_SPINLOCKPUSH_HH
+#define CLICK_SPINLOCKPUSH_HH
+#include <click/element.hh>
+#include <click/sync.hh>
+CLICK_DECLS
+
+/*
+ * =c
+ * SpinlockPush(LOCK)
+ * =s threads
+ * acquires a spinlock, push the packets then release the lock
+ * =d
+ * Acquires the spinlock named LOCK. LOCK must be defined in a SpinlockInfo
+ * element. The packet is then pushed through the pipeline and when the
+ * processing down the push path is done, releases the lock.
+ *
+ * =n
+ * Ensure that a push path will not be traversed by multiple threads at the same
+ * time while SpinlockAcquire/SpinlockRelease work for any path but do not
+ * support dropping packets between a SpinlockAcquire and a SpinlockRelease
+ *
+ * =a SpinlockInfo, SpinlockAcquire, SpinlockRelease
+ */
+
+class SpinlockPush : public Element { public:
+
+    SpinlockPush()			: _lock(0) {}
+    ~SpinlockPush()			{}
+
+    const char *class_name() const	{ return "SpinlockPush"; }
+    const char *port_count() const	{ return PORTS_1_1; }
+    const char *processing() const	{ return PUSH; }
+
+    int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
+
+    void push(int,Packet *p)	{ _lock->acquire(); output(0).push(p); _lock->release(); }
+
+  private:
+
+    Spinlock *_lock;
+
+};
+
+CLICK_ENDDECLS
+#endif


### PR DESCRIPTION
A PR for two elements I wrote I re-used multiple times that may be of interest.
- EtherRewrite element :
Overwrite an ethernet source and destination address. This is usefull for a configuration where there is no bridge on the other end of a given output link, meaning that the source and destination address for all packets going through that link will be constant. Strip(14)->EntherEncap, or EnsureEther would rewrite the ethertype, which would need to explicitly take care of all possible ethertype. This can be replaced by two StoreEtherAddress but I think it is more "clean".

- SpinlockPush element for push paths : 
Acquire a lock, push a packet, then release the lock. Contrary to a SpinlockAcquire/Release duo, it supports dropping packets. It is practical if some elements between this one and the next PushToPull (or discarding element) are not MT-safe, as only one thread will traverse the downstream path at anyone time.
That was my first way to go for ToDpdkDevice. But it did meant to lock per paquet, which is far too expensive (ToDpdkDevice lock per burst). But I think this element may still be usefull in some cases as there is still many non-threadsafe elements in Click.