### PR TITLE
Add travis tests for DPDK and Netmap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,27 @@
+cache:
+  apt: true
+  directories:
+    - dpdk-2.1.0
+    - tcpdump-4.7.4
+    - netmap-11.1
 language: c++
 compiler:
   - gcc
   - clang
-script: ./configure --disable-linuxmodule --enable-ip6 --enable-json && make && make check
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y tcpdump libpcap-dev time
-#addons:
-#  apt:
-#    packages:
-#    - tcpdump
-#    - libpcap-dev
-#    - time
-#sudo: false
+script:
+  - ./configure --disable-linuxmodule --enable-ip6 --enable-json && make && make check
+  #Trying to build with DPDK support. Tests are not launched as the flags are different using DPDK due to EAL. Also, DPDK does not cope well with clang
+  - if [ "$CC" != "clang" ] ; then ./configure --disable-linuxmodule --enable-user-multithread --enable-dpdk && make ; fi
+  - ./configure --disable-linuxmodule --enable-user-multithread --with-netmap=`pwd`/netmap-11.1/sys/ && make && make check
+
+install:
+  - export PATH=$PATH:`pwd`/tcpdump-4.7.4/sbin/ && if [ ! -e "tcpdump-4.7.4/sbin/tcpdump" ] ; then wget http://www.tcpdump.org/release/tcpdump-4.7.4.tar.gz && tar -zxf tcpdump-4.7.4.tar.gz && cd tcpdump-4.7.4 && ./configure --prefix=`pwd` && make && make install && cd .. ; fi
+  - export RTE_SDK=`pwd`/dpdk-2.1.0 && export RTE_TARGET=x86_64-native-linuxapp-gcc && if [ ! -e "$RTE_SDK/$RTE_TARGET/include/rte_version.h" ] ; then wget http://dpdk.org/browse/dpdk/snapshot/dpdk-2.1.0.tar.gz && tar -zxf dpdk-2.1.0.tar.gz && cd dpdk-2.1.0 && make config T=$RTE_TARGET && make install T=$RTE_TARGET && cd .. ; fi
+  - if [ ! -e "netmap-11.1/sys/net/netmap.h" ] ; then wget https://github.com/luigirizzo/netmap/archive/v11.1.tar.gz && tar -xvf v11.1.tar.gz && cd netmap-11.1 && cd LINUX && ./configure --no-drivers && cd .. && cd .. ; fi
+addons:
+  apt:
+    packages:
+      - libpcap-dev
+      - time
+      - linux-headers-3.13.0-40-generic
+sudo: false

--- a/elements/userlevel/fromdpdkdevice.cc
+++ b/elements/userlevel/fromdpdkdevice.cc
@@ -23,9 +23,6 @@
 #include <click/error.hh>
 #include <click/standard/scheduleinfo.hh>
 
-#include <rte_ethdev.h>
-#include <rte_mbuf.h>
-#include <rte_version.h>
 #include "fromdpdkdevice.hh"
 
 CLICK_DECLS

--- a/elements/userlevel/todpdkdevice.cc
+++ b/elements/userlevel/todpdkdevice.cc
@@ -21,9 +21,6 @@
 #include <click/error.hh>
 #include <click/algorithm.hh>
 
-#include <rte_ethdev.h>
-#include <rte_mbuf.h>
-
 #include "todpdkdevice.hh"
 
 CLICK_DECLS

--- a/include/click/dpdkdevice.hh
+++ b/include/click/dpdkdevice.hh
@@ -1,6 +1,23 @@
 #ifndef CLICK_DPDKDEVICE_HH
 #define CLICK_DPDKDEVICE_HH
 
+//Prevent bug under some configurations (like travis-ci's one) where these macros get undefined
+#ifndef UINT8_MAX
+#define UINT8_MAX 255
+#endif
+#ifndef UINT16_MAX
+#define UINT16_MAX 65535
+#endif
+
+#include <rte_common.h>
+#include <rte_eal.h>
+#include <rte_ethdev.h>
+#include <rte_lcore.h>
+#include <rte_mbuf.h>
+#include <rte_mempool.h>
+#include <rte_pci.h>
+#include <rte_version.h>
+
 #include <click/packet.hh>
 #include <click/error.hh>
 #include <click/hashmap.hh>

--- a/lib/dpdkdevice.cc
+++ b/lib/dpdkdevice.cc
@@ -18,16 +18,6 @@
 #include <click/config.h>
 #include <click/dpdkdevice.hh>
 
-#include <rte_common.h>
-#include <rte_eal.h>
-#include <rte_ethdev.h>
-#include <rte_lcore.h>
-#include <rte_mbuf.h>
-#include <rte_mempool.h>
-#include <rte_pci.h>
-#include <rte_version.h>
-
-
 CLICK_DECLS
 
 /* Wraps rte_eth_dev_socket_id(), which may return -1 for valid ports when NUMA


### PR DESCRIPTION
Also correct a DPDK compile bug which happened on travis environment.

Regarding Netmap, the full "make check" is run even if there is no Netmap-specific tests, because it is compiled also with the --enable-user-multithread. MT implies a lot of compile flags at multiple place in Click, and CI both with and without MT has proven very helpful for my own developments.

When DPDK is compiled, "make check" is not called as the arguments are changed when DPDK is enabled. There is no DPDK-specific tests for now anyway. DPDK 2.1 is not happy with clang, so dpdk compile test is avoided when compiling with clang. The DPDK build test is still useful as there is some compilation flags about DPDK in multiple places and the DPDK compile process could be harmed by other changes.

I also added installation of tcpdump from source as it cannot be installed using the new travis container-based infrastructure. But ba8b82d21dcaffad69f396a238d6772d54296fe7 make the test skipped even when tcpdump is available? Frankly I don't understand a thing of testie source code, so It's difficult to debug...

tcpdump, dpdk and netmap installation folders are cached so the first travis build is very long, but it is faster for subsequent builds.