### PR TITLE
fix DPDK TX burst size

### DIFF
--- a/elements/userlevel/todpdkdevice.cc
+++ b/elements/userlevel/todpdkdevice.cc
@@ -163,7 +163,7 @@ void ToDPDKDevice::flush_internal_queue(InternalQueue &iqueue) {
             // The sub_burst wraps around the ring
             sub_burst = _iqueue_size - iqueue.index;
         r = rte_eth_tx_burst(_port_id, _queue_id, &iqueue.pkts[iqueue.index],
-                             iqueue.nr_pending);
+                             sub_burst);
 
         iqueue.nr_pending -= r;
         iqueue.index += r;


### PR DESCRIPTION
TX burst is split into sub_bursts in case the burst size is too large or wraps around the ring

fix pointer out of range exception when the burst wraps around the ring