### PR TITLE
packet.hh: Fix shift_header_annotations in Linux >= 3.11

### DIFF
--- a/include/click/packet.hh
+++ b/include/click/packet.hh
@@ -320,7 +320,8 @@ class Packet { public:
     //@}
 
 #if CLICK_LINUXMODULE
-# if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24) && NET_SKBUFF_DATA_USES_OFFSET
+# if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24) && NET_SKBUFF_DATA_USES_OFFSET) || \
+     (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 11, 0))
   protected:
     typedef typeof(((struct sk_buff*)0)->mac_header) mac_header_type;
     typedef typeof(((struct sk_buff*)0)->network_header) network_header_type;
@@ -2062,7 +2063,11 @@ Packet::shift_header_annotations(const unsigned char *old_head,
 {
 #if CLICK_LINUXMODULE
     struct sk_buff *mskb = skb();
-# if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24) && NET_SKBUFF_DATA_USES_OFFSET
+    /* From Linux 2.6.24 - 3.10, the header offsets are integers if
+     * NET_SKBUFF_DATA_USES_OFFSET is 1.  From 3.11 onward, they're
+     * always integers. */
+# if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24) && NET_SKBUFF_DATA_USES_OFFSET) || \
+     (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 11, 0))
     (void) old_head;
     mskb->mac_header += (mskb->mac_header == (mac_header_type) ~0U ? 0 : extra_headroom);
     mskb->network_header += (mskb->network_header == (network_header_type) ~0U ? 0 : extra_headroom);


### PR DESCRIPTION
Prior to Linux 3.11, the locations of the various protocol layer
headers (MAC, network, transport) were stored in the skbuff as
pointers for 32-bit kernels and offsets for 64-bit kernels.  In Linux
3.11, this was changed so that they were always stored as 16-bit offsets
regardless of the kernel word size.  As a result the adjustments made by
Packet::shift_header_annotations were incorrect on 32-bit kernels
beginning with Linux 3.11

The actual manifestation of this problem was that the header annotations
were incorrect after an expensive_uniqueify.