### PR TITLE
Check for double queue assignment in DPDK

### DIFF
--- a/include/click/dpdkdevice.hh
+++ b/include/click/dpdkdevice.hh
@@ -4,6 +4,7 @@
 #include <click/packet.hh>
 #include <click/error.hh>
 #include <click/hashmap.hh>
+#include <click/vector.hh>
 
 CLICK_DECLS
 
@@ -47,19 +48,14 @@ private:
 
     struct DevInfo {
         inline DevInfo() :
-            n_rx_queues(0), n_tx_queues(0), promisc(false), n_rx_descs(0),
-            n_tx_descs(0) {}
-        inline DevInfo(DPDKDevice::Dir dir, unsigned queue_id, bool promisc,
-                       unsigned n_desc) :
-            n_rx_queues((dir == DPDKDevice::RX) ? queue_id + 1 : 0),
-            n_tx_queues((dir == DPDKDevice::TX) ? queue_id + 1 : 0),
-            promisc(promisc),
-            n_rx_descs((dir == DPDKDevice::RX) ? n_desc : 256),
-            n_tx_descs((dir == DPDKDevice::TX) ? n_desc : 1024)
-            {}
+            rx_queues(0,false), tx_queues(0,false), promisc(false), n_rx_descs(0),
+            n_tx_descs(0) {
+            rx_queues.reserve(128);
+            tx_queues.reserve(128);
+        }
 
-        unsigned n_rx_queues;
-        unsigned n_tx_queues;
+        Vector<bool> rx_queues;
+        Vector<bool> tx_queues;
         bool promisc;
         unsigned n_rx_descs;
         unsigned n_tx_descs;

--- a/include/click/dpdkdevice.hh
+++ b/include/click/dpdkdevice.hh
@@ -65,7 +65,7 @@ private:
     static HashMap<unsigned, DevInfo> _devs;
     static struct rte_mempool** _pktmbuf_pools;
 
-    static int initialize_device(unsigned port_id, const DevInfo &info,
+    static int initialize_device(unsigned port_id, DevInfo &info,
                                  ErrorHandler *errh) CLICK_COLD;
 
     static bool alloc_pktmbufs() CLICK_COLD;

--- a/lib/dpdkdevice.cc
+++ b/lib/dpdkdevice.cc
@@ -107,11 +107,11 @@ int DPDKDevice::initialize_device(unsigned port_id, const DevInfo &info,
     dev_conf.rx_adv_conf.rss_conf.rss_key = NULL;
     dev_conf.rx_adv_conf.rss_conf.rss_hf = ETH_RSS_IP;
 
-    if (rte_eth_dev_configure(port_id, info.n_rx_queues, info.n_tx_queues,
+    if (rte_eth_dev_configure(port_id, info.rx_queues.size(), info.tx_queues.size(),
                               &dev_conf) < 0)
         return errh->error(
             "Cannot initialize DPDK port %u with %u RX and %u TX queues",
-            port_id, info.n_rx_queues, info.n_tx_queues);
+            port_id, info.rx_queues.size(), info.tx_queues.size());
     struct rte_eth_rxconf rx_conf;
 #if RTE_VER_MAJOR >= 2
     memcpy(&rx_conf, &dev_info.default_rxconf, sizeof rx_conf);
@@ -134,7 +134,7 @@ int DPDKDevice::initialize_device(unsigned port_id, const DevInfo &info,
     tx_conf.txq_flags |= ETH_TXQ_FLAGS_NOMULTSEGS | ETH_TXQ_FLAGS_NOOFFLOADS;
 
     int numa_node = DPDKDevice::get_port_numa_node(port_id);
-    for (unsigned i = 0; i < info.n_rx_queues; ++i) {
+    for (unsigned i = 0; i < info.rx_queues.size(); ++i) {
         if (rte_eth_rx_queue_setup(
                 port_id, i, info.n_rx_descs, numa_node, &rx_conf,
                 _pktmbuf_pools[numa_node]) != 0)
@@ -143,7 +143,7 @@ int DPDKDevice::initialize_device(unsigned port_id, const DevInfo &info,
                 i, port_id, numa_node);
     }
 
-    for (unsigned i = 0; i < info.n_tx_queues; ++i)
+    for (unsigned i = 0; i < info.tx_queues.size(); ++i)
         if (rte_eth_tx_queue_setup(port_id, i, info.n_tx_descs, numa_node,
                                    &tx_conf) != 0)
             return errh->error(
@@ -161,6 +161,31 @@ int DPDKDevice::initialize_device(unsigned port_id, const DevInfo &info,
     return 0;
 }
 
+/**
+ * Set v[id] to true in vector v, expanding it if necessary. If id is 0, the first
+ * 	available slot will be taken.
+ * If v[id] is already true, this function return false. True if it is a new slot
+ * 	or if the existing slot was false.
+ */
+bool set_slot(Vector<bool> &v, int &id) {
+	if (id <= 0) {
+		int i;
+		for (i = 0; i < v.size(); i ++) {
+			if (!v[i]) break;
+		}
+		id = i;
+		if (id >= v.size())
+			v.resize(id + 1, false);
+	}
+	if (id >= v.size()) {
+		v.resize(id + 1,false);
+	}
+	if (v[id])
+		return false;
+	v[id] = true;
+	return true;
+}
+
 int DPDKDevice::add_device(unsigned port_id, DPDKDevice::Dir dir,
                            int &queue_id, bool promisc, unsigned n_desc,
                            ErrorHandler *errh)
@@ -171,30 +196,40 @@ int DPDKDevice::add_device(unsigned port_id, DPDKDevice::Dir dir,
 
     DevInfo *info = _devs.findp(port_id);
     if (!info) {
-        DevInfo info(dir, (queue_id < 0) ? 0 : queue_id, promisc, n_desc);
-        _devs.insert(port_id, info);
-    } else {
-        if (dir == RX) {
-            if (info->n_rx_queues > 0 && promisc != info->promisc)
-                return errh->error(
-                    "Some elements disagree on whether or not device %u should"
-                    " be in promiscuous mode", port_id);
-            info->promisc |= promisc;
-            if (n_desc != info->n_rx_descs)
-                return errh->error(
-                    "Some elements disagree on the number of RX descriptors "
-                    "for device %u", port_id);
-            info->n_rx_queues =
-                1 + ((queue_id <= 0) ? info->n_rx_queues : queue_id);
-        } else {
-            if (n_desc != info->n_tx_descs)
-                return errh->error(
-                    "Some elements disagree on the number of TX descriptors "
-                    "for device %u", port_id);
-            info->n_tx_queues =
-                1 + ((queue_id <= 0) ? info->n_tx_queues : queue_id);
-        }
+        _devs.insert(port_id, DevInfo());
+        info = _devs.findp(port_id);
     }
+
+	if (dir == RX) {
+		if (info->rx_queues.size() > 0 && promisc != info->promisc)
+			return errh->error(
+				"Some elements disagree on whether or not device %u should"
+				" be in promiscuous mode", port_id);
+		info->promisc |= promisc;
+		if (n_desc > 0) {
+			if (n_desc != info->n_rx_descs && info->rx_queues.size() > 0)
+				return errh->error(
+						"Some elements disagree on the number of RX descriptors "
+						"for device %u", port_id);
+			info->n_rx_descs = n_desc;
+		}
+		if (!set_slot(info->rx_queues,queue_id))
+			return errh->error(
+						"Some elements are assigned to the same RX queue "
+						"for device %u", port_id);
+	} else {
+		if (n_desc > 0) {
+			if (n_desc != info->n_tx_descs && info->tx_queues.size() > 0)
+				return errh->error(
+						"Some elements disagree on the number of TX descriptors "
+						"for device %u", port_id);
+			info->n_tx_descs = n_desc;
+		}
+		if (!set_slot(info->tx_queues,queue_id))
+			return errh->error(
+						"Some elements are assigned to the same TX queue "
+						"for device %u", port_id);
+	}
 
     return 0;
 }

--- a/lib/dpdkdevice.cc
+++ b/lib/dpdkdevice.cc
@@ -290,7 +290,7 @@ void DPDKDevice::fake_free_pkt(unsigned char *, size_t, void *)
 {
 }
 
-int DPDKDevice::NB_MBUF = 65536*8;
+int DPDKDevice::NB_MBUF = 65536;
 int DPDKDevice::MBUF_SIZE =
     2048 + sizeof (struct rte_mbuf) + RTE_PKTMBUF_HEADROOM;
 int DPDKDevice::MBUF_CACHE_SIZE = 256;


### PR DESCRIPTION
Partially solve #227, using a vector allows to assign queues out of order, for example a FromDPDKDevice to queue 2 than 1, 0, etc... It is also used to find holes in the queue assignment and prevent double assignment to the same queue (unsupported by DPDK).

I also lower the default number of MBUFS to 65536, it can be changed using DPDKInfo(N) anyway.

