### PR TITLE
Allow shared buffer to go through ToDPDKDevice safely

### DIFF
--- a/elements/userlevel/fromdpdkdevice.cc
+++ b/elements/userlevel/fromdpdkdevice.cc
@@ -71,11 +71,14 @@ bool FromDPDKDevice::run_task(Task * t)
 
     unsigned n = rte_eth_rx_burst(_port_id, _queue_id, pkts, _burst_size);
     for (unsigned i = 0; i < n; ++i) {
-        rte_prefetch0(rte_pktmbuf_mtod(pkts[i], void *));
+        unsigned char* data = rte_pktmbuf_mtod(pkts[i], unsigned char *);
+        rte_prefetch0(data);
         WritablePacket *p =
-            Packet::make(rte_pktmbuf_mtod(pkts[i], unsigned char *),
+            Packet::make(data,
                          rte_pktmbuf_data_len(pkts[i]), DPDKDevice::free_pkt,
-                         pkts[i]);
+                         pkts[i],
+                         rte_pktmbuf_headroom(pkts[i]),
+                         rte_pktmbuf_tailroom(pkts[i]));
         p->set_packet_type_anno(Packet::HOST);
 
         output(0).push(p);

--- a/elements/userlevel/todpdkdevice.cc
+++ b/elements/userlevel/todpdkdevice.cc
@@ -123,6 +123,7 @@ inline struct rte_mbuf* get_mbuf(Packet* p, bool create=true) {
         mbuf = (struct rte_mbuf *) p->destructor_argument();
         rte_pktmbuf_pkt_len(mbuf) = p->length();
         rte_pktmbuf_data_len(mbuf) = p->length();
+        mbuf->data_off = p->headroom();
         if (p->shared()) {
             /*Prevent DPDK from freeing the buffer. When all shared packet
              * are freed, DPDKDevice::free_pkt will effectively destroy it.*/

--- a/elements/userlevel/todpdkdevice.cc
+++ b/elements/userlevel/todpdkdevice.cc
@@ -121,7 +121,16 @@ inline struct rte_mbuf* get_mbuf(Packet* p, bool create=true) {
 
     if (likely(DPDKDevice::is_dpdk_packet(p))) {
         mbuf = (struct rte_mbuf *) p->destructor_argument();
-        p->set_buffer_destructor(DPDKDevice::fake_free_pkt);
+        rte_pktmbuf_pkt_len(mbuf) = p->length();
+        rte_pktmbuf_data_len(mbuf) = p->length();
+        if (p->shared()) {
+            /*Prevent DPDK from freeing the buffer. When all shared packet
+             * are freed, DPDKDevice::free_pkt will effectively destroy it.*/
+            rte_mbuf_refcnt_update(mbuf, 1);
+        } else {
+            //Reset buffer, let DPDK free the buffer when it wants
+            p->reset_buffer();
+        }
     } else if (create) {
         mbuf = rte_pktmbuf_alloc(DPDKDevice::get_mpool(rte_socket_id()));
         memcpy((void*) rte_pktmbuf_mtod(mbuf, unsigned char *), p->data(),

--- a/include/click/dpdkdevice.hh
+++ b/include/click/dpdkdevice.hh
@@ -40,12 +40,10 @@ public:
     static int initialize(ErrorHandler *errh);
 
     inline static bool is_dpdk_packet(Packet* p) {
-            return p->buffer_destructor() == DPDKDevice::free_pkt;
+            return p->buffer_destructor() == DPDKDevice::free_pkt || (p->data_packet() && is_dpdk_packet(p->data_packet()));
     }
 
     static void free_pkt(unsigned char *, size_t, void *pktmbuf);
-
-    static void fake_free_pkt(unsigned char *, size_t, void *pktmbuf);
 
     static unsigned int get_nb_txdesc(unsigned port_id);
 

--- a/include/click/packet.hh
+++ b/include/click/packet.hh
@@ -65,7 +65,7 @@ class Packet { public:
     typedef void (*buffer_destructor_type)(unsigned char* buf, size_t sz, void* argument);
     static WritablePacket* make(unsigned char* data, uint32_t length,
 				buffer_destructor_type buffer_destructor,
-                                void* argument = (void*) 0) CLICK_WARN_UNUSED_RESULT;
+                                void* argument = (void*) 0, int headroom = 0, int tailroom = 0) CLICK_WARN_UNUSED_RESULT;
 #endif
 
     static void static_cleanup();

--- a/include/click/packet.hh
+++ b/include/click/packet.hh
@@ -639,6 +639,10 @@ class Packet { public:
 	*reinterpret_cast<click_aliasable_void_pointer_t *>(xanno()->c + i) = const_cast<void *>(x);
     }
 
+    inline Packet* data_packet() {
+        return _data_packet;
+    }
+
     inline void clear_annotations(bool all = true);
     inline void copy_annotations(const Packet *);
     //@}

--- a/lib/dpdkdevice.cc
+++ b/lib/dpdkdevice.cc
@@ -282,10 +282,6 @@ void DPDKDevice::free_pkt(unsigned char *, size_t, void *pktmbuf)
     rte_pktmbuf_free((struct rte_mbuf *) pktmbuf);
 }
 
-void DPDKDevice::fake_free_pkt(unsigned char *, size_t, void *)
-{
-}
-
 int DPDKDevice::NB_MBUF = 65536;
 int DPDKDevice::MBUF_SIZE =
     2048 + sizeof (struct rte_mbuf) + RTE_PKTMBUF_HEADROOM;

--- a/lib/packet.cc
+++ b/lib/packet.cc
@@ -577,6 +577,8 @@ Packet::make(uint32_t headroom, const void *data,
  * @param length length of packet
  * @param destructor destructor function
  * @param argument argument to destructor function
+ * @param headroom headroom available before the data pointer
+ * @param tailroom tailroom available after data + length
  * @return new packet, or null if no packet could be created
  *
  * The packet's data pointer becomes the @a data: the data is not copied
@@ -591,7 +593,7 @@ Packet::make(uint32_t headroom, const void *data,
  * null. */
 WritablePacket *
 Packet::make(unsigned char *data, uint32_t length,
-	     buffer_destructor_type destructor, void* argument)
+	     buffer_destructor_type destructor, void* argument, int headroom, int tailroom)
 {
 # if HAVE_CLICK_PACKET_POOL
     WritablePacket *p = WritablePacket::pool_allocate(false);
@@ -600,8 +602,10 @@ Packet::make(unsigned char *data, uint32_t length,
 # endif
     if (p) {
 	p->initialize();
-	p->_head = p->_data = data;
-	p->_tail = p->_end = data + length;
+	p->_head = data - headroom;
+	p->_data = data;
+	p->_tail = data + length;
+	p->_end = p->_tail + tailroom;
 	p->_destructor = destructor;
         p->_destructor_argument = argument;
     }


### PR DESCRIPTION
In the current scheme, we do not check if the packet is shared in ToDPDKDevice. So if a buffer from a shared packet is given to DPDK, DPDK may release it after the packet has been sent, and reuse it in FromDPDKDevice. If the cloned packet has been kept until then, its buffer will contain garbage... It would be bad luck that the buffer remains that long, but it could happen...

Now, if the packet is shared, we'll increment DPDK buffer reference counter and our packet buffer will not be reseted. When all clone are freed, the DPDK destructor will finaly be called and DPDK will decrement the usage counter by 1. When the buffer is effectively sent by the NIC it will also decrement the usage counter by 1. The last of the two will really free the buffer.

Note that having shared packet going through ToDPDKDevice should be avoided as that path is slower.

I'd like discussions around this (@kohler @bcronje ?) , as when Netmap will get back its Zero-Copy inside Click, this solution won't be possible as there is no reference counter updated by Netmap.

We could also say that keeping a cloned DPDK buffer inside Click enough time to send it, do a full NIC ring wrap-around, recycle it, and receive a new packet inside it (after receiving a whole ring of packets too) is just the user misbehaving...