### PR TITLE
Add git revision to click -v version output

### DIFF
--- a/configure
+++ b/configure
@@ -577,7 +577,7 @@ MAKEFLAGS=
 # Identity of this package.
 PACKAGE_NAME='click'
 PACKAGE_TARNAME='click'
-PACKAGE_VERSION='2.1'
+PACKAGE_VERSION='2.1 '`git rev-parse --short HEAD 2> /dev/null`
 PACKAGE_STRING='click 2.1'
 PACKAGE_BUGREPORT=''
 PACKAGE_URL=''


### PR DESCRIPTION
A possible method to pull in the git revision into the click -v version output, which is useful when troubleshooting live systems running the binary.

Produces: click (Click) 2.1 a824ac9