### PR TITLE
lock/unlock_tasks() around Task::cleanup()

### DIFF
--- a/lib/task.cc
+++ b/lib/task.cc
@@ -223,6 +223,8 @@ Task::cleanup()
     GIANT_REQUIRED;
 #endif
     if (initialized()) {
+        RouterThread *th = _thread;
+        th->lock_tasks();
         // Mark the task as unscheduled.
 	strong_unschedule();
 
@@ -255,6 +257,7 @@ Task::cleanup()
 
 	_owner = 0;
 	_thread = 0;
+        th->unlock_tasks();
     }
 }
 


### PR DESCRIPTION
A race condition between Task::cleanup() and RouterThread::driver() is causing NULL pointer dereference panic occasionally while the click config is getting rewritten.

To address this issue, a lock is added surrounding the Task::cleanup() function in the attempt to prevent RouterThread::driver() from accessing the dying tasks.

The original click implementation did try to address the race condition between Task::cleanup() and Routerthread::driver() by guarding the critical section with _pending_lock, but some race conditions still sneak through in some scenarios.

I listed these scenarios inline the codes with comments starting with //SCENE# in both racing functions. 

[SCENE 1]

```

1.    void
2.    Task::cleanup()
3.    {
4.        ...
5.        if (initialized()) {
6.            strong_unschedule();
7.  
8.            //SCENE1: the Task tries to remove itself from pending list here if
9.            //it finds itself in the list by checking with the following function:
10.            //
11.            //   inline bool on_pending_list() { return _pending_nextptr.x !=0 ;}
12.            //
13.            //but the RouterThread::driver() may still be accessing this Task
14.            //after removing it from the list by setting _pending_nextptr.x = 0,
15.            //see SCENE1 below, line 25 from the 2nd segment of code.
16.            if (on_pending_list())
17.                remove_pending() { //NOTE: non-C++ style for explaining what's done in the function
18.                      _pending_lock.acquire();
19.                      ... remove itself from pending list
20.                      _pending_lock.release();
21.                };
22.            ...
23.            while (on_pending_list())
24.                click_relax_fence();
25.            ...
26.            if (on_scheduled_list()) {
27.                 ... try to remove itself from schedule list
28.                 ... or waiting for itself being removed from the list by RouterThread:driver()
29.            }
30.            _owner = 0;
31.            _thread = 0;
32.        }
33.    }

```

```

1.  void
2.  RouterThread::driver() {
3.      ...
4.      driver_lock_tasks();
5.      ...
6.      while (1) {
7.          ...
8.          if (_pending_head.x)
9.              process_pending() { //NOTE: non-C++ style for explaining what's done in this function.
10.                  _pending_lock.acquire();
11.                  //NOTE: try to claim the list by saving the head into a local var
12.                  my_pending = _pending_head;
13.                  _pending_lock.release();
14.                  ...
15.                  while (my_pending.x > 1) {
16.                      Task *t = my_pending.t;
17.                      my_pending = t->_pending_nextptr;
18.  
19.  
20.                      //SCENE1: remove Task from pending_list by reseting t->pending_nextptr.x
21.                      //which makes Task::cleanup() think that the task is not in pending list
22.                      //and then goes ahead to destroy the Task.
23.                      t->_pending_nextptr.x = 0;
24.  
25.                      //Then, the following function call to process_pending()
26.                      //will get several different types of null pointer dereference panic
27.                      //depending on the timing when the task is being destroyed.
28.                      t->process_pending (this) {//NOTE: non-C++ style for showing the what's done in the function
29.                        ...
30.                        if (status.home_thread_id != this->thread_id())
31.                          move_thread_second_half();
32.                        else if (status.is_scheduled) {
33.                          if (router()->running())
34.                            fast_schedule();
35.                          else
36.                            add_pending();
37.                        }
38.                      };
39.                   }
40.              };
41.          ...
42.          run_tasks(...);
43.          ...
44.          timer_set().run_timers(...);
45.          ...
46.          run_os() {  //NOTE: non-C++ style to show what's done in the function
47.              driver_unlock_tasks();
48.              ...
49.              schedule();
50.              ...
51.              driver_lock_tasks();
52.          };
53.      }
54.  }

```

 [SCENE 2]

```

1.    void
2.    Task::cleanup()
3.    {
4.        ...
5.        if (initialized()) {
6.            strong_unschedule();
7.  
8.            if (on_pending_list())
9.                remove_pending() { //NOTE: non-C++ style for explaining what's done in the function
10.                      _pending_lock.acquire();
11.                      ... remove itself from pending list
12.                      _pending_lock.release();
13.                };
14.            ...
15.            //SCENE2: spinlock to wait until it gets removed from pending list.
16.            //but as in SCENE1, the task is being used even after it's removed (from pending list). 
17.            //See SCENE2 below.
18.            while (on_pending_list())
19.                click_relax_fence();
20.            ...
21.            if (on_scheduled_list()) {
22.                 ... try to remove itself from schedule list
23.                 ... or waiting for itself being removed from the list by RouterThread:driver()
24.            }
25.            _owner = 0;
26.            _thread = 0;
27.        }
28.    }

```

```

1.  void
2.  RouterThread::driver() {
3.      ...
4.      driver_lock_tasks();
5.      ...
6.      while (1) {
7.          ...
8.          if (_pending_head.x)
9.              process_pending() { //NOTE: non-C++ style for explaining what's done in this function.
10.                  _pending_lock.acquire();
11.                  //NOTE: try to claim the list by saving the head into a local var
12.                  my_pending = _pending_head;
13.                  _pending_lock.release();
14.                  ...
15.                  while (my_pending.x > 1) {
16.                      Task *t = my_pending.t;
17.                      my_pending = t->_pending_nextptr;
18.  
19.  
20.                      //SCENE2: remove Task from pending_list by reseting t->pending_nextptr.x
21.                      //which allows Task::cleanup() to get out of spinlock and destroy Task
22.                      t->_pending_nextptr.x = 0;
23.  
24.                      //Then, the following function call to process_pending()
25.                      //will get several different types of null pointer dereference panic
26.                      //depending on the timing when the task is being destroyed.
27.                      t->process_pending (this) {//NOTE: non-C++ style for showing the what's done in the function
28.                        ...
29.                        if (status.home_thread_id != this->thread_id())
30.                          move_thread_second_half();
31.                        else if (status.is_scheduled) {
32.                          if (router()->running())
33.                            fast_schedule();
34.                          else
35.                            add_pending();
36.                        }
37.                      };
38.                   }
39.              };
40.          ...
41.          run_tasks(...);
42.          ...
43.          timer_set().run_timers(...);
44.          ...
45.          run_os() {  //NOTE: non-C++ style to show what's done in the function
46.              driver_unlock_tasks();
47.              ...
48.              schedule();
49.              ...
50.              driver_lock_tasks();
51.          };
52.      }
53.  }

```

The two scenarios above raised a question: 

> Can we just move this line 22 around to fix the problem? 

```
22. t->_pending_nextptr.x = 0;
```

The answer is probably "no," or it would be a "Yes, but difficult." 
The reasons are explained inline the following code segment.

```

1.  void
2.  RouterThread::driver() {
3.      ...
4.      driver_lock_tasks();
5.      ...
6.      while (1) {
7.          ...
8.          if (_pending_head.x)
9.              process_pending() { //NOTE: non-C++ style for explaining what's done in this function.
10.                  _pending_lock.acquire();
11.                  //NOTE: try to claim the list by saving the head into a local var
12.                  my_pending = _pending_head;
13.                  _pending_lock.release();
14.                  ...
15.                  while (my_pending.x > 1) {
16.                      Task *t = my_pending.t;
17.                      my_pending = t->_pending_nextptr;
18.  
19.                      t->_pending_nextptr.x = 0;
20. 
21.                      //It seems that move line 19 above to after calling t->process_pending() at line 26 below
22.                      //will fix the problem, but we can't do that because the _pending_nextptr will have different values after 
23.                      //process_pending(), depending on different conditions deeper inside the three inner functions. 
24.                      //Also, moving "reseting _pending_nextptr.x" around may potentially mess up the multithread environment.
25.  
26.                      t->process_pending (this) {//NOTE: non-C++ style for showing the what's done in the function
27.                        ...
28.                        if (status.home_thread_id != this->thread_id())
29.                          move_thread_second_half();
30.                        else if (status.is_scheduled) {
31.                          if (router()->running())
32.                            fast_schedule();
33.                          else
34.                            add_pending();
35.                        }
36.                      };
37. 
38.                   }
39.              };
40.          ...
41.          run_tasks(...);
42.          ...
43.          timer_set().run_timers(...);
44.          ...
45.          run_os() {  //NOTE: non-C++ style to show what's done in the function
46.              driver_unlock_tasks();
47.              ...
48.              schedule();
49.              ...
50.              driver_lock_tasks();
51.          };
52.      }
53.  }

```

Taking all the above thoughts into consideration, plus the fact (or assumption) that 'Tasks' rarely kill themselves (only when the router is getting killed), the easiest and safest way to address the race condition will be blocking the RouterThread driver while a task is killing itself.

ThreadRouter::driver() releases the task lock inside the function call to "run_os()" (line 52 from the 2nd segment of code), allowing other thread to block the driver. 
