### PR TITLE
print error code in write handler call

### DIFF
--- a/conf/wifi/write_handler
+++ b/conf/wifi/write_handler
@@ -6,5 +6,5 @@ if [ $# -lt 2 ]; then
 fi
 
 ARGS=$@
-printf "write $ARGS\nquit\n" | nc 127.0.0.1 7777|grep "Click::ControlSocket"|grep "200 Write handler"|grep "200 Goodbye"
+printf "write $ARGS\nquit\n" | nc 127.0.0.1 7777 | grep -v ^Click::ControlSocket | grep -v ^DATA | grep -v "200 Goodbye!"| grep -v "200 Write handler"
 


### PR DESCRIPTION
In case of a failed request, the write handler script does not print the http error code, nor the reason.