### PR TITLE
dpdk: Add one travis test per DPDK version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,55 @@
 cache:
   apt: true
   directories:
+    - dpdk-1.8.0
+    - dpdk-2.0.0
     - dpdk-2.1.0
+    - dpdk-2.2.0
     - tcpdump-4.7.4
     - netmap-11.1
 language: c++
 compiler:
   - gcc
   - clang
+matrix:
+  exclude:
+    - compiler: clang
+      env: FRAMEWORK=dpdk VERSION=1.8.0
+    - compiler: clang
+      env: FRAMEWORK=dpdk VERSION=2.0.0
+    - compiler: clang
+      env: FRAMEWORK=dpdk VERSION=2.1.0
+    - compiler: clang
+      env: FRAMEWORK=dpdk VERSION=2.2.0
+env:
+  global:
+    - FLAGS="--enable-ip6 --enable-json -disable-linuxmodule"
+  matrix:
+    - FRAMEWORK=netmap VERSION=11.1
+    - FRAMEWORK=dpdk VERSION=1.8.0
+    - FRAMEWORK=dpdk VERSION=2.0.0
+    - FRAMEWORK=dpdk VERSION=2.1.0
+    - FRAMEWORK=dpdk VERSION=2.2.0
+    - FRAMEWORK=vanilla
 script:
-  - ./configure --disable-linuxmodule --enable-ip6 --enable-json && make && make check
-  #Trying to build with DPDK support. Tests are not launched as the flags are different using DPDK due to EAL. Also, DPDK does not cope well with clang
-  - if [ "$CC" != "clang" ] ; then ./configure --disable-linuxmodule --enable-user-multithread --enable-dpdk && make ; fi
-  - ./configure --disable-linuxmodule --enable-user-multithread --with-netmap=`pwd`/netmap-11.1/sys/ && make && make check
+  - compile=true ; check=true
 
+  - if [ $FRAMEWORK == "netmap" ] ; then FRAMEWORK_FLAGS="--enable-user-multithread  --with-netmap=`pwd`/netmap-$VERSION/sys/" ; fi
+
+  - if [ $FRAMEWORK == "dpdk" ] ; then check=false && FRAMEWORK_FLAGS="--enable-user-multithread --enable-dpdk" && export RTE_SDK=`pwd`/dpdk-$VERSION && export RTE_TARGET=x86_64-native-linuxapp-gcc && if [ ! -e "$RTE_SDK/$RTE_TARGET/include/rte_version.h" ] ; then wget http://dpdk.org/browse/dpdk/snapshot/dpdk-$VERSION.tar.gz && tar -zxf dpdk-$VERSION.tar.gz && cd dpdk-$VERSION && make config T=$RTE_TARGET && make install T=$RTE_TARGET && cd .. ; fi ; fi
+
+  - if [ $FRAMEWORK == "vanilla" ] ; then
+      FRAMEWORK_FLAGS="" ;
+    fi
+
+  - if [ $compile == true ] ; then
+      ./configure $FLAGS $FRAMEWORK_FLAGS && make ;
+    fi
+  - if [ $check == true ] ; then
+      make check ;
+    fi
 install:
   - export PATH=$PATH:`pwd`/tcpdump-4.7.4/sbin/ && if [ ! -e "tcpdump-4.7.4/sbin/tcpdump" ] ; then wget http://www.tcpdump.org/release/tcpdump-4.7.4.tar.gz && tar -zxf tcpdump-4.7.4.tar.gz && cd tcpdump-4.7.4 && ./configure --prefix=`pwd` && make && make install && cd .. ; fi
-  - export RTE_SDK=`pwd`/dpdk-2.1.0 && export RTE_TARGET=x86_64-native-linuxapp-gcc && if [ ! -e "$RTE_SDK/$RTE_TARGET/include/rte_version.h" ] ; then wget http://dpdk.org/browse/dpdk/snapshot/dpdk-2.1.0.tar.gz && tar -zxf dpdk-2.1.0.tar.gz && cd dpdk-2.1.0 && make config T=$RTE_TARGET && make install T=$RTE_TARGET && cd .. ; fi
   - if [ ! -e "netmap-11.1/sys/net/netmap.h" ] ; then wget https://github.com/luigirizzo/netmap/archive/v11.1.tar.gz && tar -xvf v11.1.tar.gz && cd netmap-11.1 && cd LINUX && ./configure --no-drivers && cd .. && cd .. ; fi
 addons:
   apt:


### PR DESCRIPTION
Use a build matrix in travis to test all DPDK versions. This offer more parallelism in Travis as one concurrent job will be launched per framework : netmap, dpdk, or vanilla.

The exclude part is not very clean, but DPDK is not compatible with clang. This solution does not launch a job in travis for nothing. If I keep last method (a condition in the job itself to do nothing if $CC==clang), it would launch all jobs for clang, always exiting doing nearly nothing except installing packets. Not very clean either. Ultimately the better solution will come from Travis...
caa6ece

Make the test a little heavier but be sure to not break anything... 1.8, 2.0, 2.1 and 2.2 are probably the most used. I'll come later for compatibility with 16.04.

We could also argument this for Kernel click and test Click against some well-picked kernel headers version. What do people think of this? Way to go, or stick to one test case per framework?

