### PR TITLE
Added address length defines and fixed whitespace consistency

### DIFF
--- a/include/clicknet/ether.h
+++ b/include/clicknet/ether.h
@@ -2,6 +2,8 @@
 #ifndef CLICKNET_ETHER_H
 #define CLICKNET_ETHER_H
 
+#include "ip.h"
+
 /*
  * <clicknet/ether.h> -- Ethernet and ARP headers, based on one of the BSDs.
  *
@@ -14,10 +16,12 @@
  * Also see the relevant IEEE 802 standards.
  */
 
+#define ETHER_ADDR_LEN 6
+
 struct click_ether {
-    uint8_t	ether_dhost[6];		/* 0-5   Ethernet destination address */
-    uint8_t	ether_shost[6];		/* 6-11  Ethernet source address      */
-    uint16_t	ether_type;		/* 12-13 Ethernet protocol	      */
+    uint8_t	ether_dhost[ETHER_ADDR_LEN];	/* 0-5   Ethernet destination address */
+    uint8_t	ether_shost[ETHER_ADDR_LEN];	/* 6-11  Ethernet source address      */
+    uint16_t	ether_type;			/* 12-13 Ethernet protocol	      */
 } CLICK_SIZE_PACKED_ATTRIBUTE;
 
 #define ETHERTYPE_IP		0x0800
@@ -32,7 +36,7 @@ struct click_ether {
 
 struct click_arp {		/* Offsets relative to ARP (Ethernet) header */
     uint16_t	ar_hrd;		/* 0-1 (14-15)  hardware address format      */
-#define ARPHRD_ETHER    1	/*		  Ethernet 10Mbps	     */
+#define ARPHRD_ETHER	1	/*		  Ethernet 10Mbps	     */
 #define ARPHRD_IEEE802	6	/*		  token ring     	     */
 #define ARPHRD_ARCNET	7	/*		  Arcnet         	     */
 #define ARPHRD_FRELAY	15	/*		  frame relay    	     */
@@ -43,7 +47,7 @@ struct click_arp {		/* Offsets relative to ARP (Ethernet) header */
     uint8_t	ar_hln;		/* 4   (18)     hardware address length      */
     uint8_t	ar_pln;		/* 5   (19)     protocol address length      */
     uint16_t	ar_op;		/* 6-7 (20-21)  opcode (command)	     */
-#define ARPOP_REQUEST   1	/*		  ARP request		     */
+#define ARPOP_REQUEST	1	/*		  ARP request		     */
 #define ARPOP_REPLY	2	/*		  ARP reply		     */
 #define ARPOP_REVREQUEST 3	/*		  reverse request: hw->proto */
 #define ARPOP_REVREPLY	4	/*		  reverse reply		     */
@@ -52,22 +56,22 @@ struct click_arp {		/* Offsets relative to ARP (Ethernet) header */
 };
 
 struct click_ether_arp {
-    struct click_arp ea_hdr;	/* 0-7   (14-21)  fixed-size ARP header	     */
-    uint8_t	arp_sha[6];	/* 8-13  (22-27)  sender hardware address    */
-    uint8_t	arp_spa[4];	/* 14-17 (28-31)  sender protocol address    */
-    uint8_t	arp_tha[6];	/* 18-23 (32-37)  target hardware address    */
-    uint8_t	arp_tpa[4];	/* 24-27 (38-41)  target protocol address    */
+    struct click_arp ea_hdr;			/* 0-7   (14-21)  fixed-size ARP header	     */
+    uint8_t	arp_sha[ETHER_ADDR_LEN];	/* 8-13  (22-27)  sender hardware address    */
+    uint8_t	arp_spa[IP_ADDR_LEN];		/* 14-17 (28-31)  sender protocol address    */
+    uint8_t	arp_tha[ETHER_ADDR_LEN];	/* 18-23 (32-37)  target hardware address    */
+    uint8_t	arp_tpa[IP_ADDR_LEN];		/* 24-27 (38-41)  target protocol address    */
 };
 
 
 /* Ethernet with VLAN (802.1q) */
 
 struct click_ether_vlan {
-    uint8_t     ether_dhost[6];		/* 0-5   Ethernet source address      */
-    uint8_t     ether_shost[6];		/* 6-11  Ethernet destination address */
-    uint16_t    ether_vlan_proto;	/* 12-13 == ETHERTYPE_8021Q	      */
-    uint16_t    ether_vlan_tci;		/* 14-15 tag control information      */
-    uint16_t    ether_vlan_encap_proto;	/* 16-17 Ethernet protocol	      */
+    uint8_t	ether_dhost[ETHER_ADDR_LEN];	/* 0-5   Ethernet source address      */
+    uint8_t	ether_shost[ETHER_ADDR_LEN];	/* 6-11  Ethernet destination address */
+    uint16_t	ether_vlan_proto;		/* 12-13 == ETHERTYPE_8021Q	      */
+    uint16_t	ether_vlan_tci;			/* 14-15 tag control information      */
+    uint16_t	ether_vlan_encap_proto;		/* 16-17 Ethernet protocol	      */
 } CLICK_SIZE_PACKED_ATTRIBUTE;
 
 
@@ -87,30 +91,30 @@ struct click_ether_macctl {
 
 /* define structure of Neighborhood Solicitation Message */
 struct click_nd_sol {
-    uint8_t type;
-    uint8_t code;
-    uint16_t checksum;
-    uint32_t reserved;
-    uint8_t nd_tpa[16];
-    uint8_t option_type;   /*option type: 1 (source link-layer add) */
-    uint8_t option_length; /*option length: 1 (in units of 8 octets) */
-    uint8_t nd_sha[6];    /*source link-layer address */
+    uint8_t	type;
+    uint8_t	code;
+    uint16_t	checksum;
+    uint32_t	reserved;
+    uint8_t	nd_tpa[16];
+    uint8_t	option_type;		/*option type: 1 (source link-layer add) */
+    uint8_t	option_length;		/*option length: 1 (in units of 8 octets) */
+    uint8_t	nd_sha[ETHER_ADDR_LEN];	/*source link-layer address */
 };
 
 /* define structure of Neighborhood Advertisement Message -reply to multicast neighborhood solitation message */
 struct click_nd_adv {
-    uint8_t type;
-    uint8_t code;
-    uint16_t checksum;
-    uint8_t flags; /* bit 1: sender_is_router
-                      bit 2: solicited
-		      bit 3: override
-		      all other bits should be zero */
-    uint8_t reserved[3];
-    uint8_t nd_tpa[16];
-    uint8_t option_type;    /* option type: 2 (target link-layer add) */
-    uint8_t option_length;  /* option length: 1 (in units of 8 octets) */
-    uint8_t nd_tha[6];     /* source link-layer address */
+    uint8_t	type;
+    uint8_t	code;
+    uint16_t	checksum;
+    uint8_t	flags; /* bit 1: sender_is_router
+			  bit 2: solicited
+			  bit 3: override
+			  all other bits should be zero */
+    uint8_t	reserved[3];
+    uint8_t	nd_tpa[16];
+    uint8_t	option_type;		/* option type: 2 (target link-layer add) */
+    uint8_t	option_length;		/* option length: 1 (in units of 8 octets) */
+    uint8_t	nd_tha[ETHER_ADDR_LEN];	/* source link-layer address */
 };
 
 

--- a/include/clicknet/ip.h
+++ b/include/clicknet/ip.h
@@ -20,6 +20,8 @@ CLICK_CXX_PROTECT
  *   RFC3168	The Addition of Explicit Congestion Notification (ECN) to IP
  */
 
+#define IP_ADDR_LEN 4
+
 struct click_ip {
 #if CLICK_BYTE_ORDER == CLICK_BIG_ENDIAN
     unsigned	ip_v : 4;		/* 0     version == 4		     */
@@ -87,7 +89,7 @@ struct click_ip {
 #define IP_PROTO_DCCP		33
 #define IP_PROTO_RSVP		46
 #define IP_PROTO_GRE		47
-#define IP_PROTO_ICMP6          58
+#define IP_PROTO_ICMP6		58
 #define IP_PROTO_CFTP		62
 #define IP_PROTO_SATNET		64
 #define IP_PROTO_MITSUBNET	65

--- a/include/clicknet/ip6.h
+++ b/include/clicknet/ip6.h
@@ -13,7 +13,7 @@ CLICK_CXX_PROTECT
 # include <netinet/in.h>
 #endif
 
-#define IP6_ADDR_LEN 32
+#define IP6_ADDR_LEN 16
 
 struct click_ip6 {
     union {

--- a/include/clicknet/ip6.h
+++ b/include/clicknet/ip6.h
@@ -13,6 +13,8 @@ CLICK_CXX_PROTECT
 # include <netinet/in.h>
 #endif
 
+#define IP6_ADDR_LEN 32
+
 struct click_ip6 {
     union {
 	struct {


### PR DESCRIPTION
Added the following macros defines to ether.h, ip.h, and ip6.h, respectively:
- ETHER_ADDR_LEN
- IP_ADDR_LEN
- IP6_ADDR_LEN
