### PR TITLE
dpdk: EnsureDPDKBuffer

### DIFF
--- a/elements/userlevel/ensuredpdkbuffer.cc
+++ b/elements/userlevel/ensuredpdkbuffer.cc
@@ -1,0 +1,85 @@
+// -*- c-basic-offset: 4; related-file-name: "ensuredpdkbuffer.hh" -*-
+/*
+ * ensuredpdkbuffer.{cc,hh} - Ensure DPDK Buffer
+ * Tom Barbette
+ *
+ * Copyright (c) 2015 University of Liège
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
+#include <click/config.h>
+#include <click/args.hh>
+#include <click/dpdkdevice.hh>
+#include "ensuredpdkbuffer.hh"
+
+CLICK_DECLS
+
+
+EnsureDPDKBuffer::EnsureDPDKBuffer() : _force(false), _extra_headroom(0), _warn_count(0)
+{
+}
+
+EnsureDPDKBuffer::~EnsureDPDKBuffer()
+{
+}
+
+
+int
+EnsureDPDKBuffer::configure(Vector<String> &conf, ErrorHandler *errh)
+{
+    if (Args(conf, this, errh)
+    .read_p("FORCE_COPY", _force)
+    .read_p("EXTRA_HEADROOM", _extra_headroom)
+    .complete() < 0)
+    return -1;
+
+    return 0;
+}
+
+inline Packet*
+EnsureDPDKBuffer::smaction(Packet* p) {
+    if (!_force && (DPDKDevice::is_dpdk_packet(p))) {
+        return p;
+    } else {
+        struct rte_mbuf* mbuf = DPDKDevice::get_pkt();
+        if (!mbuf) {
+            p->kill();
+            if (_warn_count++ < 5)
+                click_chatter("%s : No more DPDK Buffer ! Dropping packet.",name().c_str());
+            return 0;
+        }
+        WritablePacket* q = WritablePacket::make(
+                (unsigned char*)mbuf->buf_addr,
+                DPDKDevice::MBUF_DATA_SIZE,
+                DPDKDevice::free_pkt,
+                (void*)mbuf);
+        if (q->copy(p,rte_pktmbuf_headroom(mbuf) + _extra_headroom)) {
+            p->kill();
+            return q;
+        } else {
+            p->kill();
+            return 0;
+        }
+    }
+}
+
+Packet*
+EnsureDPDKBuffer::simple_action(Packet* p) {
+    return smaction(p);
+}
+
+
+
+
+CLICK_ENDDECLS
+ELEMENT_REQUIRES(userlevel dpdk)
+EXPORT_ELEMENT(EnsureDPDKBuffer)

--- a/elements/userlevel/ensuredpdkbuffer.hh
+++ b/elements/userlevel/ensuredpdkbuffer.hh
@@ -1,0 +1,51 @@
+// -*- c-basic-offset: 4 -*-
+#ifndef CLICK_ENSUREDPDKBUFFER_HH
+#define CLICK_ENSUREDPDKBUFFER_HH
+#include <click/config.h>
+#include <click/element.hh>
+
+CLICK_DECLS
+
+/*
+ * =title EnsureDPDKBuffer
+ *
+ * =c
+ *
+ * EnsureDPDKBuffer()
+ *
+ * =d
+ *
+ * Ensure that all packets passing through this element are using DPDK buffer and not Click or mmap'd buffers. Packet will be copied to a new DPDK buffer if it's not the case.
+ *
+ * =item FORCE_COPY
+ *
+ * Always copy packets to a new DPDK buffer
+ *
+ * =item EXTRA_HEADROOM
+ *
+ * When a copy is done, add an extra headroom space
+ */
+
+
+class EnsureDPDKBuffer: public Element  {
+
+public:
+    EnsureDPDKBuffer() CLICK_COLD;
+    ~EnsureDPDKBuffer() CLICK_COLD;
+
+    const char *class_name() const        { return "EnsureDPDKBuffer"; }
+    const char *port_count() const        { return PORTS_1_1; }
+    const char *processing() const        { return AGNOSTIC; }
+    int configure(Vector<String> &conf, ErrorHandler *errh);
+
+    Packet* smaction(Packet*);
+    Packet* simple_action(Packet*);
+
+private:
+    bool _force;
+    int _extra_headroom;
+    int _warn_count;
+};
+
+CLICK_ENDDECLS
+#endif

--- a/elements/userlevel/fromdpdkdevice.cc
+++ b/elements/userlevel/fromdpdkdevice.cc
@@ -120,8 +120,8 @@ int FromDPDKDevice::reset_count_handler(const String &, Element *e, void *,
 
 void FromDPDKDevice::add_handlers()
 {
-	add_read_handler("count", count_handler, 0);
-	add_write_handler("reset_count", reset_count_handler, 0,
+    add_read_handler("count", count_handler, 0);
+    add_write_handler("reset_count", reset_count_handler, 0,
                           Handler::BUTTON);
 }
 

--- a/elements/userlevel/todpdkdevice.cc
+++ b/elements/userlevel/todpdkdevice.cc
@@ -39,8 +39,8 @@ ToDPDKDevice::~ToDPDKDevice()
 int ToDPDKDevice::configure(Vector<String> &conf, ErrorHandler *errh)
 {
     int n_desc = -1;
-	String dev;
-	bool allow_nonexistent = false;
+    String dev;
+    bool allow_nonexistent = false;
 
     if (Args(conf, this, errh)
         .read_mp("PORT", dev)

--- a/include/click/packet.hh
+++ b/include/click/packet.hh
@@ -271,6 +271,7 @@ class Packet { public:
     inline void shrink_data(const unsigned char *data, uint32_t length);
     inline void change_headroom_and_length(uint32_t headroom, uint32_t length);
 #endif
+    bool copy(Packet* p, int headroom=0);
     //@}
 
     /** @name Header Pointers */

--- a/lib/packet.cc
+++ b/lib/packet.cc
@@ -613,6 +613,22 @@ Packet::make(unsigned char *data, uint32_t length,
 }
 #endif
 
+/** @brief Copy the content and annotations of another packet (userlevel).
+ * @param source packet
+ * @param headroom for the new packet
+ */
+bool
+Packet::copy(Packet* p, int headroom)
+{
+    if (headroom + p->length() > buffer_length())
+        return false;
+    _data = _head + headroom;
+    memcpy(_data,p->data(),p->length());
+    _tail = _data + p->length();
+    copy_annotations(p);
+    set_mac_header(p->mac_header() ? data() + p->mac_header_offset() : 0);
+    set_network_header(p->network_header() ? data() + p->network_header_offset() : 0, p->network_header_length());
+}
 
 //
 // UNIQUEIFICATION


### PR DESCRIPTION
Ensure that a packet is backed by a DPDK buffer. Allows to preload
packets and send them faster as there will be no copy when sending
the packet to DPDK.