### PR TITLE
IPFilter: Load and optimize rules in pairs

### DIFF
--- a/elements/standard/classification.cc
+++ b/elements/standard/classification.cc
@@ -203,6 +203,12 @@ Program::add_insn(Vector<int> &tree, int offset, uint32_t value, uint32_t mask)
 }
 
 void
+Program::add_raw_insn(Insn new_insn)
+{
+    _insn.push_back(new_insn);
+}
+
+void
 Program::redirect_subtree(int first, int last, int success, int failure)
 {
     for (int i = first; i < last; ++i) {
@@ -212,6 +218,34 @@ Program::redirect_subtree(int first, int last, int success, int failure)
 		in.j[k] = success;
 	    else if (in.j[k] == j_failure)
 		in.j[k] = failure;
+    }
+}
+
+void
+Program::redirect_unfinished_insn_tree(int new_target)
+{
+    for (int i = 0; i < ninsn(); i++) {
+        Insn &insn = _insn[i];
+        for (int k = 0; k < 2; k++) {
+            //check for unlinked jumps
+            if (insn.j[k] == j_never + 1) {
+                insn.j[k] = new_target;
+            }
+        }
+    }
+}
+
+void
+Program::offset_insn_tree(int step_offset)
+{
+    for (int i = 0; i < ninsn(); i++) {
+        Insn &insn = _insn[i];
+        for (int k = 0; k < 2; k++) {
+            //only positive jumps point to other states
+            if (insn.j[k] > 0) {
+                insn.j[k] +=  step_offset;
+            }
+        }
     }
 }
 

--- a/elements/standard/classification.hh
+++ b/elements/standard/classification.hh
@@ -176,6 +176,7 @@ class Program { public:
     }
 
     void add_insn(Vector<int> &tree, int offset, uint32_t value, uint32_t mask);
+    void add_raw_insn(Insn new_insn);
 
     Vector<int> init_subtree() const;
     void start_subtree(Vector<int> &tree) const;
@@ -196,6 +197,9 @@ class Program { public:
     void optimize(const int *offset_map_begin, const int *offset_map_end, int last_offset);
 
     void warn_unused_outputs(int noutputs, ErrorHandler *errh) const;
+
+    void offset_insn_tree(int step_offset);
+    void redirect_unfinished_insn_tree(int new_target);
 
     int match(const Packet *p);
 


### PR DESCRIPTION
This patch aims to improve rule compiler optimization runtime.
It does so by changing the order rules are compiled into a program tree.

The original algorithm constructs the program tree by sequentially
appending each of the rules to the end of one single tree,
then running one single optimize operation on that whole tree.

Since the optimization algorithm has a polynomial runtime, this can get
prohibitively slow for large trees.

This patch loads rules two-by-two into small trees, optimizes them, then
combines these trees into a series of smaller, optimized trees. The process
is then repeated until there is only one tree left.

By optimizing each tree as it goes, the new algorithm keeps the tree
size as small as possible, avoiding the polynomial growth in runtime.

The reduction in rule load times varies with the rule set in question,
however we are seeing a reduction in load times of roughly 1/3 on
average. In some cases as much as 97% reduction.

The load time reduction varies quite a bit by rule set, but on average
we are seeing about 1/3 reduction. In some cases the reduction is as
great as 97%, going from 1150ms to 29ms (This rule set had 44 rules, and
45k tree nodes.) These numbers were obtained by running click testies
with various rule sets on server hardware.