### PR TITLE
straccum: Fix const-correctness

### DIFF
--- a/include/click/straccum.hh
+++ b/include/click/straccum.hh
@@ -160,7 +160,7 @@ inline StringAccum &operator<<(StringAccum &sa, uint64_t x);
 #if defined(CLICK_USERLEVEL) || defined(CLICK_TOOL) || defined(CLICK_MINIOS)
 StringAccum &operator<<(StringAccum &sa, double x);
 #endif
-StringAccum &operator<<(StringAccum &sa, void *ptr);
+StringAccum &operator<<(StringAccum &sa, const void *ptr);
 
 
 /** @brief Construct an empty StringAccum (with length 0). */

--- a/lib/straccum.cc
+++ b/lib/straccum.cc
@@ -347,7 +347,7 @@ operator<<(StringAccum &sa, double d)
     @brief Append hexadecimal representation of @a ptr's value to @a sa.
     @return @a sa */
 StringAccum &
-operator<<(StringAccum &sa, void *ptr)
+operator<<(StringAccum &sa, const void *ptr)
 {
     if (char *x = sa.reserve(30)) {
 	int len = sprintf(x, "%p", ptr);


### PR DESCRIPTION
The operator<< implementation for a void* should really be a const
void*.  This allows sending a "this" pointer inside a const function,
among other things.