### PR TITLE
Reverse broadcast order

### DIFF
--- a/elements/etherswitch/etherswitch.cc
+++ b/elements/etherswitch/etherswitch.cc
@@ -49,7 +49,7 @@ EtherSwitch::broadcast(int source, Packet *p)
   int n = noutputs();
   assert((unsigned) source < (unsigned) n);
   int sent = 0;
-  for (int i = 0; i < n; i++)
+  for (int i = n - 1; i >=0 ; i--)
     if (i != source) {
       Packet *pp = (sent < n - 2 ? p->clone() : p);
       output(i).push(pp);


### PR DESCRIPTION
When the broadcast() method is called from within a ListenEtherSwitch, dumping the packet to the “listen” port last may cause inconsistencies when attaching this port to a ToDump.  Because of the packet processing order, this causes e.g. the first ARP reply to appear in the dump file before the ARP request. Broadcasting  the packet to the listen port first fixes this issue.