### PR TITLE
ThreadSafeQueue needs to update xhead and xtail during hotswap.

### DIFF
--- a/elements/standard/threadsafequeue.cc
+++ b/elements/standard/threadsafequeue.cc
@@ -46,6 +46,18 @@ ThreadSafeQueue::live_reconfigure(Vector<String> &conf, ErrorHandler *errh)
 }
 
 void
+ThreadSafeQueue::take_state(Element *e, ErrorHandler *errh)
+{
+    SimpleQueue *q = (SimpleQueue *)e->cast("SimpleQueue");
+    if (!q)
+        return;
+
+    SimpleQueue::take_state(e, errh);
+    _xhead = head();
+    _xtail = tail();
+}
+
+void
 ThreadSafeQueue::push(int, Packet *p)
 {
     // Code taken from SimpleQueue::push().

--- a/elements/standard/threadsafequeue.hh
+++ b/elements/standard/threadsafequeue.hh
@@ -59,6 +59,7 @@ class ThreadSafeQueue : public FullNoteQueue { public:
     void *cast(const char *);
 
     int live_reconfigure(Vector<String> &conf, ErrorHandler *errh);
+    void take_state(Element*, ErrorHandler*);
 
     void push(int port, Packet *);
     Packet *pull(int port);


### PR DESCRIPTION
If there are packets in the queue during hotswap, it resulted in a corrupt queue endlessly spinning in push() as tail and xtail were out of sync. This commit ensures we update xtail and xhead during hotswap.