### PR TITLE
click: Fix privatehandler-01 false negative

### DIFF
--- a/test/handlers/privatehandler-01.testie
+++ b/test/handlers/privatehandler-01.testie
@@ -6,16 +6,15 @@ msleep () {
    click -e "DriverManager(wait $1ms)"
 }
 
-(while [ ! -f PORT ]; do msleep 1; done && { cat CSIN; msleep 3; } | nc localhost `cat PORT` >CSOUT) &
+(while [ ! -f PORT ]; do msleep 1; done && cat CSIN | nc localhost `cat PORT` >CSOUT) &
 click -e 'cs :: ControlSocket(tcp, 41930+);
 s :: Script(print >PORT $(cs.port),
 	    print "SCARY => $(cat SCARY)",
-	    wait 3s, stop)'
+	    wait 1s, stop)'
 
 %file CSIN
 read s.add 1 1
 read s.cat SCARY
-write stop
 
 %file SCARY
 This is a scary file!
@@ -25,7 +24,6 @@ Click::ControlSocket/1.{{\d+}}
 200 Read handler{{.*}}
 DATA 1
 2511 No handler named 's.cat'
-200 Write handler 'stop' OK
 
 %expect stdout
 SCARY => This is a scary file!


### PR DESCRIPTION
The privatehandler-01.testie occasionally fails with false negatives.
One example failure:
   ../click/test/handlers/privatehandler-01.testie:28: file CSOUT has unexpected value starting at line 5
   ../click/test/handlers/privatehandler-01.testie:28: CSOUT:5: expected '200 Write handler 'stop' OK'
   ../click/test/handlers/privatehandler-01.testie:28: CSOUT:5: but got  '<end of file>'
Similar failures have been observed where _none_ of CSOUT has been
written prior to evaluation by testie. These failures are reproducible
within 3000 iterations or so (it helps if the machine is running another
load, like a parallel kernel build):
   $ while true; do test/testie test/handlers/privatehandler-01.testie || break; done

These failures stem from a race between the script exiting and the
redirected output to the CSOUT file, since the testie shell script does
not wait for background tasks to complete before exiting. After the
ControlSocket processes the "write stop" command from the CSIN file and
sends the reply '200 Write handler 'stop' OK', it's possible to exit the
driver() loop and click main() and read the expected before the background
'nc' task has read the socket and written to CSOUT.

In extreme cases, it's even possible for the SCARY file not to have been
written to stdout yet; this race is more easily reproducible by
inserting 'wait 5' between writing the PORT file and cat SCARY.

Instead of stopping the router from the ControlSocket script, always
stop the router from the click Script 's', after a 1 sec. delay.
Remove the associated expected output from the CSOUT file.
Remove the original attempted fix (commit 717aa25f
"Improve user-level ControlSocket test reliability.")