### PR TITLE
Do not use SELECT_WRITE on push input.

### DIFF
--- a/elements/userlevel/socket.cc
+++ b/elements/userlevel/socket.cc
@@ -343,7 +343,7 @@ Socket::selected(int fd, int)
       fcntl(_active, F_SETFL, O_NONBLOCK);
       fcntl(_active, F_SETFD, FD_CLOEXEC);
 
-      add_select(_active, SELECT_READ | SELECT_WRITE);
+      add_select(_active, SELECT_READ);
     }
 
     // read data from socket


### PR DESCRIPTION
Write events are only needed if input port is pull and run_task already manages adding and removing SELECT_WRITE in that scenario. This commit fixes Click constantly polling selected on push input. Push input does not require polling as it already uses a blocking select in push to setup for writing.