### PR TITLE
FromDPDKDevice now calls set_mac_header

### DIFF
--- a/elements/userlevel/fromdpdkdevice.cc
+++ b/elements/userlevel/fromdpdkdevice.cc
@@ -92,6 +92,7 @@ bool FromDPDKDevice::run_task(Task * t)
                          rte_pktmbuf_headroom(pkts[i]),
                          rte_pktmbuf_tailroom(pkts[i]));
         p->set_packet_type_anno(Packet::HOST);
+        p->set_mac_header(p->data());
 
         output(0).push(p);
     }

--- a/elements/userlevel/fromdpdkdevice.cc
+++ b/elements/userlevel/fromdpdkdevice.cc
@@ -92,7 +92,7 @@ bool FromDPDKDevice::run_task(Task * t)
                          rte_pktmbuf_headroom(pkts[i]),
                          rte_pktmbuf_tailroom(pkts[i]));
         p->set_packet_type_anno(Packet::HOST);
-        p->set_mac_header(p->data());
+        p->set_mac_header(data);
 
         output(0).push(p);
     }


### PR DESCRIPTION
FromDPDKDevice now calls set_mac_header, like other sources.

This closes #352.