### PR TITLE
ToDevice(.k) : Set queue_mapping to 0

### DIFF
--- a/elements/linuxmodule/todevice.cc
+++ b/elements/linuxmodule/todevice.cc
@@ -511,6 +511,9 @@ ToDevice::queue_packet(Packet *p, struct netdev_queue *txq)
     // apparently some devices in Linux 2.6 require it
     skb1->dev = dev;
 
+    //reset queue index until proper MQ support
+    skb1->queue_mapping = 0;
+
 #ifdef IFF_XMIT_DST_RELEASE
     /*
      * If device doesnt need skb->dst, release it right now while


### PR DESCRIPTION
Somehow, even with only one queue in RX this field is danglingto value != 0.
Fix #359 . In ixgbe and i40e that lead to accessing an inexisting queue.
But also probably others.

Proper support would be to initialize the device with multiple queues,
or use multiple ToDevice with a QUEUE argument and use one queue per
thread. But that's for another day...