### PR TITLE
return if pcap_activate fails

### DIFF
--- a/elements/userlevel/fromdevice.cc
+++ b/elements/userlevel/fromdevice.cc
@@ -286,6 +286,7 @@ FromDevice::open_pcap(String ifname, int snaplen, bool promisc,
         errh->error("%s: %s", ifname.c_str(), fetch_pcap_error(p, 0));
         pcap_close(p);
         p = 0;
+	return p;
     } else if (r > 0)
         errh->warning("%s: %s", ifname.c_str(), fetch_pcap_error(p, 0));
 


### PR DESCRIPTION
If a Click process is started without enough privileges to start pcap on a device (usually root), a segmentation fault will happen, because FromDevice::open_pcap() does not return after pcap_activate() failing, but proceeds to pcap_setnonblock().