### PR TITLE
json: avoid buffer overread in Json::parse_primitive

### DIFF
--- a/elements/json/json.cc
+++ b/elements/json/json.cc
@@ -858,7 +858,7 @@ Json::parse_primitive(const String &str, const char *begin, const char *end)
 	    ++s;
 	    if (s != end && (*s == '+' || *s == '-'))
 		++s;
-	    if (s == end || s[1] < '0' || s[1] > '9')
+	    if (s == end || s[0] < '0' || s[0] > '9')
 		return 0;
 	    for (++s; s != end && isdigit((unsigned char) *s); )
 		++s;


### PR DESCRIPTION
It looks like this code as copy-and-pasted from similar code above it that
checks s+1==end.  That code actually uses s[1] and knows s[0], so it's
correct.  This code is not correct and the effect is that it will overread
when parsing a number with a single-digit exponent at the end of a buffer.
It also allows malformed numbers with a valid second digit but invalid
second digit to parse.

Found by @bannable.