### PR TITLE
Bug fix for too short IPv6 packet assertion

### DIFF
--- a/elements/ip6/checkip6header.cc
+++ b/elements/ip6/checkip6header.cc
@@ -134,7 +134,7 @@ CheckIP6Header::simple_action(Packet *p)
 
   // shorten packet according to IP6 payload length field
   if(ntohs(ip->ip6_plen) < (plen-40))
-    p->take(plen - 40 - ip->ip6_plen);
+    p->take(plen - 40 - ntohs(ip->ip6_plen));
   return(p);
 
  bad:


### PR DESCRIPTION
When an IPv6 packet doesn't match the header size, the part that chops the packet down was missing a ntohs().  This causes an assertion later and click dies.