### PR TITLE
Fix issue removing click kernel module.

### DIFF
--- a/lib/master.cc
+++ b/lib/master.cc
@@ -205,6 +205,9 @@ Master::kill_router(Router *router)
         return;
     }
 
+    /* Stop threads setting _stop_flag */
+    request_stop();
+
 #if CLICK_LINUXMODULE
     preempt_disable();
 #endif


### PR DESCRIPTION
The click router threads refuse to die because no one is setting the _stop_flag.
There is an infinite loop in RouterThread::driver() function.
Call request_stop killing router in master.cc to fix the problem.