### PR TITLE
Fix cp_skip_space return value on whitespace string and add test

### DIFF
--- a/elements/test/confparsetest.cc
+++ b/elements/test/confparsetest.cc
@@ -69,6 +69,10 @@ ConfParseTest::initialize(ErrorHandler *errh)
     CHECK(cp_uncomment("  \" /*???  */ \"  ") == "\" /*???  */ \"");
     CHECK(cp_unquote("\"\\n\" abc /* 123 */ '/* def */'") == "\n abc /* def */");
 
+    // cp_eat_space
+    CHECK(cp_eat_space("       ") == false);
+    CHECK(cp_eat_space("  a  b  ") == "a  b  ");
+
     Vector<String> v;
     cp_argvec("a, b, c", v);
     CHECK(v.size() == 3);

--- a/elements/test/confparsetest.cc
+++ b/elements/test/confparsetest.cc
@@ -70,8 +70,12 @@ ConfParseTest::initialize(ErrorHandler *errh)
     CHECK(cp_unquote("\"\\n\" abc /* 123 */ '/* def */'") == "\n abc /* def */");
 
     // cp_eat_space
-    CHECK(cp_eat_space("       ") == false);
-    CHECK(cp_eat_space("  a  b  ") == "a  b  ");
+    String eat_space = "       ";
+    CHECK(cp_eat_space(eat_space) == false);
+    CHECK(eat_space == "");
+    eat_space = "  a  b  ";
+    CHECK(cp_eat_space(eat_space) == true);
+    CHECK(eat_space == "a  b  ");
 
     Vector<String> v;
     cp_argvec("a, b, c", v);

--- a/lib/confparse.cc
+++ b/lib/confparse.cc
@@ -229,7 +229,7 @@ cp_eat_space(String &str)
     const char *begin = str.begin(), *end = str.end();
     const char *space = cp_skip_space(begin, end);
     str = str.substring(space, end);
-    return space != begin;
+    return space != end;
 }
 
 /** @brief  Test whether @a str is a valid "word".


### PR DESCRIPTION
From the documentation of eat space it should return false if the resulting string is empty. The problem is it compares the return value of cp_skip_space to the beginning of the string rather than the end which will be the return value on a whitespace string. I added a test to `confparsetest.cc`