### PR TITLE
Fix travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ script:
             wget http://fast.dpdk.org/rel/dpdk-$VERSION.tar.gz &&
             tar -zxf dpdk-$VERSION.tar.gz &&
             cd dpdk-$VERSION &&
+            sed -i "s/CONFIG_RTE_ENABLE_AVX=.*/CONFIG_RTE_ENABLE_AVX=n/g" config/common_base &&
             sed -i "s/CONFIG_RTE_KNI_KMOD=.*/CONFIG_RTE_KNI_KMOD=n/g" config/common_linuxapp &&
             sed -i "s/CONFIG_RTE_LIBRTE_KNI=.*/CONFIG_RTE_LIBRTE_KNI=n/g" config/common_linuxapp &&
             sed -i "s/CONFIG_RTE_EAL_IGB_UIO=.*/CONFIG_RTE_EAL_IGB_UIO=n/g" config/common_linuxapp &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 cache:
   apt: true
   directories:
-    - dpdk-2.2.0
     - dpdk-16.07
     - dpdk-18.05
     - tcpdump-4.7.4
@@ -13,10 +12,6 @@ compiler:
   - gcc
   - clang
 
-matrix:
-  exclude:
-    - compiler: clang
-      env: FRAMEWORK=dpdk VERSION=2.2.0
 env:
   global:
     - FLAGS="--enable-ip6 --enable-json --disable-linuxmodule"
@@ -26,7 +21,6 @@ env:
     - FRAMEWORK=vanilla
     - FRAMEWORK=umultithread
     - FRAMEWORK=netmap VERSION=11.1
-    - FRAMEWORK=dpdk VERSION=2.2.0
     - FRAMEWORK=dpdk VERSION=16.07
     - FRAMEWORK=dpdk VERSION=18.05
 

--- a/elements/ip/iproutetable.hh
+++ b/elements/ip/iproutetable.hh
@@ -70,7 +70,7 @@ should be preferred for almost all purposes.
      SortedIPLookup |  12500  |  224K   |  38s  |   29 KB
 
 A Click script containing the 167000-route dump is available at
-http://www.read.cs.ucla.edu/click/routetabletest-167k.click.gz
+https://github.com/kohler/click/wiki/files/routetabletest-167k.click.gz
 
 =head1 INTERFACE
 


### PR DESCRIPTION
In summary : 
- Fix the routetable link discussed in issues
- Travis does not always support AVX2, so disable that from DPDK
- DPDK 2.2 has also problems with travis because of headers. Anyway it's old and was not compatible with clang.

I'll push this in a few days if there is no comments/further approval.