### PR TITLE
Fix sample configuration

### DIFF
--- a/conf/ip64-nat.click
+++ b/conf/ip64-nat.click
@@ -84,10 +84,12 @@ pt46 :: ProtocolTranslator46();
 FromDevice(eth0, 1)
   	-> c; 
 
+q :: Queue(1024)
+	-> td0 :: ToDevice(eth0);
+
 c[0] 	-> nda
 	//-> Print(nda, 200)
-	-> Queue(1024)
-	-> ToDevice(eth0);
+	-> q;
 c[1] 	-> [1]nds;
 c[2]	//-> Print(before-Strip, 200) 
 	-> Strip(14)
@@ -98,8 +100,7 @@ c[2]	//-> Print(before-Strip, 200)
 
 c[3] 	//-> Print(arr, 200) 
 	-> arr	
-	-> Queue(1024)
-	-> ToDevice(eth0) ;
+	-> q;
 	
 c[4] 	//-> Print(arp-reply, 200) 
 	->[1]arp;
@@ -111,7 +112,7 @@ c[5] 	//-> Print(c5-normal-ip-pkt, 200)
 	-> rt;
 
 c[6]	//-> Print(c6-normal-ip-pkt, 200) 
-	->Discard;
+	-> Discard;
 
 rt[0]	->Print(rt0, 200) ->Discard;
 rt[1]	//->Print(rt1, 200)
@@ -153,16 +154,7 @@ pt46[0]	-> Print(after-pt460, 200)
 	-> [1]at;
 
 arp[0] 	-> Print(arp0, 200)
-	-> ToDevice(eth0);
+	-> q;
 
 nds[0]  //-> Print(nds, 200)
-	-> ToDevice(eth0);
-	
-	
-
-
-
-
-
-
-
+	-> q;

--- a/conf/ip64-nat.click
+++ b/conf/ip64-nat.click
@@ -82,13 +82,12 @@ pt64 :: ProtocolTranslator64();
 pt46 :: ProtocolTranslator46();	
 
 FromDevice(eth0, 1)
-  	-> c;
-to_eth0 :: ToDevice(eth0);
+  	-> c; 
 
 c[0] 	-> nda
 	//-> Print(nda, 200)
 	-> Queue(1024)
-	-> to_eth0;
+	-> ToDevice(eth0);
 c[1] 	-> [1]nds;
 c[2]	//-> Print(before-Strip, 200) 
 	-> Strip(14)
@@ -100,7 +99,7 @@ c[2]	//-> Print(before-Strip, 200)
 c[3] 	//-> Print(arr, 200) 
 	-> arr	
 	-> Queue(1024)
-	-> to_eth0;
+	-> ToDevice(eth0) ;
 	
 c[4] 	//-> Print(arp-reply, 200) 
 	->[1]arp;
@@ -154,10 +153,10 @@ pt46[0]	-> Print(after-pt460, 200)
 	-> [1]at;
 
 arp[0] 	-> Print(arp0, 200)
-	-> to_eth0;
+	-> ToDevice(eth0);
 
 nds[0]  //-> Print(nds, 200)
-	-> to_eth0;
+	-> ToDevice(eth0);
 	
 	
 

--- a/conf/ip64-nat2.click
+++ b/conf/ip64-nat2.click
@@ -85,13 +85,12 @@ pt64 :: ProtocolTranslator64();
 pt46 :: ProtocolTranslator46();
 
 FromDevice(eth0, 1)
-  	-> c;
-to_eth0 :: ToDevice(eth0);
+  	-> c; 
 
 c[0] 	-> nda
 	//-> Print(nda, 200)
 	-> Queue(1024)
-	-> to_eth0;
+	-> ToDevice(eth0);
 
 c[1] 	-> [1]nds;
 
@@ -102,7 +101,7 @@ c[2]	-> Strip(14)
 
 c[3] 	-> arr	
 	-> Queue(1024)
-	-> to_eth0 ;
+	-> ToDevice(eth0) ;
 	
 c[4] 	//-> Print(arp-reply, 200) 
 	->[1]arp;
@@ -154,10 +153,10 @@ pt46[0]	//-> Print(after-pt460, 200)
 	-> [1]at;
 
 arp[0] 	//-> Print(arp0, 200)
-	-> to_eth0;
+	-> ToDevice(eth0);
 
 nds[0]  //-> Print(nds, 200)
-	-> to_eth0;
+	-> ToDevice(eth0);
 	
 	
 

--- a/conf/ip64-nat2.click
+++ b/conf/ip64-nat2.click
@@ -87,10 +87,12 @@ pt46 :: ProtocolTranslator46();
 FromDevice(eth0, 1)
   	-> c; 
 
+q :: Queue(1024)
+	-> td0 :: ToDevice(eth0);
+
 c[0] 	-> nda
 	//-> Print(nda, 200)
-	-> Queue(1024)
-	-> ToDevice(eth0);
+    -> q;
 
 c[1] 	-> [1]nds;
 
@@ -100,8 +102,7 @@ c[2]	-> Strip(14)
 	-> rt6;
 
 c[3] 	-> arr	
-	-> Queue(1024)
-	-> ToDevice(eth0) ;
+	-> q;
 	
 c[4] 	//-> Print(arp-reply, 200) 
 	->[1]arp;
@@ -153,16 +154,7 @@ pt46[0]	//-> Print(after-pt460, 200)
 	-> [1]at;
 
 arp[0] 	//-> Print(arp0, 200)
-	-> ToDevice(eth0);
+	-> q;
 
 nds[0]  //-> Print(nds, 200)
-	-> ToDevice(eth0);
-	
-	
-
-
-
-
-
-
-
+	-> q;

--- a/conf/ip64-nat3.click
+++ b/conf/ip64-nat3.click
@@ -86,13 +86,12 @@ pt64 :: ProtocolTranslator64();
 pt46 :: ProtocolTranslator46();
 
 FromDevice(eth0, 1)
-  	-> c;
-to_eth0 :: ToDevice(eth0);
+  	-> c; 
 
 c[0] 	-> nda
 	//-> Print(nda, 200)
 	-> Queue(1024)
-	-> to_eth0;
+	-> ToDevice(eth0);
 
 c[1] 	-> [1]nds;
 
@@ -107,7 +106,7 @@ c[3] 	-> arr
 c[4] 	-> arr2
 	-> q;
 
-q	-> to_eth0 ;
+q	-> ToDevice(eth0) ;
 	
 c[5] 	//-> Print(arp-reply, 200) 
 	->[1]arp;
@@ -164,10 +163,10 @@ pt46[0]	-> Print(after-pt46, 200)
 	-> [1]at;
 
 arp[0] 	//-> Print(arp0, 200)
-	-> to_eth0;
+	-> ToDevice(eth0);
 
 nds[0]  -> Print(nds, 200)
-	-> to_eth0;
+	-> ToDevice(eth0);
 	
 	
 

--- a/conf/ip64-nat3.click
+++ b/conf/ip64-nat3.click
@@ -26,8 +26,6 @@ arp::ARPQuerier(18.26.4.116, 00:a0:c9:9c:fd:9e);
 arr::ARPResponder(18.26.4.116 00:a0:c9:9c:fd:9e);
 arr2::ARPResponder(18.26.4.17 00:a0:c9:9c:fd:9e);
 
-q::Queue(1024);
-
 nda :: IP6NDAdvertiser(
 	3ffe:1ce1:2:0:200::1/128 00:A0:C9:9C:FD:9E, 
 	fe80::2a0:c9ff:fe9c:fd9e/128 00:A0:C9:9C:FD:9E); 
@@ -88,10 +86,11 @@ pt46 :: ProtocolTranslator46();
 FromDevice(eth0, 1)
   	-> c; 
 
-c[0] 	-> nda
+q :: Queue(1024)
+	-> td0 :: ToDevice(eth0);
+
+c[0] 	-> nda;
 	//-> Print(nda, 200)
-	-> Queue(1024)
-	-> ToDevice(eth0);
 
 c[1] 	-> [1]nds;
 
@@ -106,8 +105,6 @@ c[3] 	-> arr
 c[4] 	-> arr2
 	-> q;
 
-q	-> ToDevice(eth0) ;
-	
 c[5] 	//-> Print(arp-reply, 200) 
 	->[1]arp;
 	
@@ -163,16 +160,7 @@ pt46[0]	-> Print(after-pt46, 200)
 	-> [1]at;
 
 arp[0] 	//-> Print(arp0, 200)
-	-> ToDevice(eth0);
+	-> q;
 
 nds[0]  -> Print(nds, 200)
-	-> ToDevice(eth0);
-	
-	
-
-
-
-
-
-
-
+	-> q;

--- a/conf/ip64-nat4.click
+++ b/conf/ip64-nat4.click
@@ -79,12 +79,11 @@ pt46 :: ProtocolTranslator46();
 
 FromDevice(eth0, 1)
   	-> c; 
-to_eth0 :: ToDevice(eth0);
 
 c[0] 	-> nda
 	//-> Print(nda, 200)
 	-> Queue(1024)
-	-> to_eth0;
+	-> ToDevice(eth0);
 
 c[1] 	-> [1]nds;
 
@@ -99,7 +98,7 @@ c[3] 	-> arr
 c[4] 	-> arr2
 	-> q;
 
-q	-> to_eth0 ;
+q	-> ToDevice(eth0) ;
 	
 c[5] 	//-> Print(arp-reply, 200) 
 	->[1]arp;
@@ -156,10 +155,10 @@ pt46[0]	-> Print(after-pt46, 200)
 	-> [1]at;
 
 arp[0] 	//-> Print(arp0, 200)
-	-> to_eth0;
+	-> ToDevice(eth0);
 
 nds[0]  -> Print(nds, 200)
-	-> to_eth0;
+	-> ToDevice(eth0);
 	
 	
 

--- a/conf/ip64-nat4.click
+++ b/conf/ip64-nat4.click
@@ -26,8 +26,6 @@ arp::ARPQuerier(18.26.4.116, 00:a0:c9:9c:fd:9e);
 arr::ARPResponder(18.26.4.116 00:a0:c9:9c:fd:9e);
 arr2::ARPResponder(18.26.4.17 00:a0:c9:9c:fd:9e);
 
-q::Queue(1024);
-
 nda :: IP6NDAdvertiser(
 	3ffe:1ce1:2:0:200::1/128 00:A0:C9:9C:FD:9E, 
 	fe80::2a0:c9ff:fe9c:fd9e/128 00:A0:C9:9C:FD:9E); 
@@ -70,7 +68,6 @@ at :: AddressTranslator(
 	1,
 	0,
 	3ffe:1ce1:2::1 ::18.26.4.17,
-	
 	0)
 
 //pt :: ProtocolTranslator();
@@ -80,10 +77,12 @@ pt46 :: ProtocolTranslator46();
 FromDevice(eth0, 1)
   	-> c; 
 
+q :: Queue(1024)
+	-> td0 :: ToDevice(eth0);
+
 c[0] 	-> nda
 	//-> Print(nda, 200)
-	-> Queue(1024)
-	-> ToDevice(eth0);
+	-> q;
 
 c[1] 	-> [1]nds;
 
@@ -92,13 +91,11 @@ c[2]	-> Strip(14)
 	-> GetIP6Address(24)
 	-> rt6;
 
-c[3] 	-> arr	
+c[3] 	-> arr
 	-> q;
 	
 c[4] 	-> arr2
 	-> q;
-
-q	-> ToDevice(eth0) ;
 	
 c[5] 	//-> Print(arp-reply, 200) 
 	->[1]arp;
@@ -155,16 +152,7 @@ pt46[0]	-> Print(after-pt46, 200)
 	-> [1]at;
 
 arp[0] 	//-> Print(arp0, 200)
-	-> ToDevice(eth0);
+	-> q;
 
 nds[0]  -> Print(nds, 200)
-	-> ToDevice(eth0);
-	
-	
-
-
-
-
-
-
-
+	-> q;


### PR DESCRIPTION
This reverts commit 2cc95243a95cb33b0ad6c4db0e4e063e6c2a0a09.

This was actually not correct as now you have multiple pull paths pulling from the same element.

I then updated the config to achieve the original intent.

Not that I'm necrophile but students do come across these files and get confused.

