### PR TITLE
Add support for 11n standard in wifi elements

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -790,6 +790,9 @@ if test "x$enable_ip6" = xyes; then
     EXTRA_DRIVER_OBJS="ip6address.o ip6flowid.o ip6table.o $EXTRA_DRIVER_OBJS"
     EXTRA_TOOL_OBJS="ip6address.o $EXTRA_TOOL_OBJS"
 fi
+if test "x$enable_wifi" = xyes; then
+    EXTRA_DRIVER_OBJS="radiotap.o $EXTRA_DRIVER_OBJS"
+fi
 AC_SUBST(EXTRA_DRIVER_OBJS)
 AC_SUBST(EXTRA_TOOL_OBJS)
 

--- a/elements/userlevel/fromdevice.cc
+++ b/elements/userlevel/fromdevice.cc
@@ -44,6 +44,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include "fakepcap.hh"
+#include <linux/sockios.h>
 
 #if FROMDEVICE_ALLOW_LINUX
 # include <sys/socket.h>

--- a/elements/userlevel/rawsocket.cc
+++ b/elements/userlevel/rawsocket.cc
@@ -34,6 +34,7 @@
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <fcntl.h>
+#include <linux/sockios.h>
 
 #ifndef __sun
 #include <sys/ioctl.h>

--- a/elements/wifi/athdescdecap.cc
+++ b/elements/wifi/athdescdecap.cc
@@ -66,7 +66,7 @@ AthdescDecap::simple_action(Packet *p)
 			eh->power = desc->xmit_power;
 			eh->rssi = desc->ack_sig_strength;
 			eh->rate = ratecode_to_dot11(desc->xmit_rate0);
-			eh->retries = desc->data_fail_count;
+			eh->max_tries = desc->data_fail_count;
 			if (desc->excessive_retries)
 				eh->flags |= WIFI_EXTRA_TX_FAIL;
 		}

--- a/elements/wifi/autoratefallback.cc
+++ b/elements/wifi/autoratefallback.cc
@@ -104,7 +104,7 @@ AutoRateFallback::process_feedback(Packet *p_in)
 
   if (used_alt_rate || !success) {
     /* step down 1 or 2 rates */
-    int down = eh->retries / 2;
+    int down = eh->max_tries / 2;
     if (down > 0) {
       down--;
     }
@@ -137,7 +137,7 @@ AutoRateFallback::process_feedback(Packet *p_in)
   }
   nfo->_wentup = false;
 
-  if (eh->retries == 0) {
+  if (eh->max_tries == 0) {
     nfo->_successes++;
   } else {
     nfo->_successes = 0;

--- a/elements/wifi/bitrate.cc
+++ b/elements/wifi/bitrate.cc
@@ -2,28 +2,34 @@
 #include "bitrate.hh"
 #include <clicknet/wifi.h>
 
+// MCS data rates (kbps)
+static const uint32_t mcs_rate_lookup[16] =
+{
+6500, 13000, 19500, 26000, 39000, 52000, 58500, 65000,
+13000, 26000, 39000, 52000, 78000, 104000, 117000, 130000
+};
 
 unsigned
 calc_transmit_time(int rate, int length)
 {
-	unsigned t_plcp_header = 96;
-	if (rate == 2) {
-		t_plcp_header = 192;
-	} else if (!is_b_rate(rate)) {
-		t_plcp_header = 20;
-  }
-	return (2 * (t_plcp_header + ((length * 8))))/ rate;
+	unsigned t_plcp_header = 0;
+	if (is_b_rate(rate)) {
+		t_plcp_header = (rate == 2) ? WIFI_PLCP_HEADER_LONG_B : WIFI_PLCP_HEADER_SHORT_B;
+	} else {
+		t_plcp_header = WIFI_PLCP_HEADER_A;
+	}
+	return (2 * length * 8) / rate + t_plcp_header;
 }
 
 unsigned
 calc_backoff(int rate, int t)
 {
 	int t_slot = is_b_rate(rate) ? WIFI_SLOT_B : WIFI_SLOT_A;
-	int cw = WIFI_CW_MIN;
-
+	int cw = is_b_rate(rate) ? WIFI_CW_MIN_B : WIFI_CW_MIN;
+	int cw_max = is_b_rate(rate) ? WIFI_CW_MAX_B : WIFI_CW_MAX;
 	/* there is backoff, even for the first packet */
 	for (int x = 0; x < t; x++) {
-		cw = WIFI_MIN(WIFI_CW_MAX, (cw + 1) * 2);
+		cw = WIFI_MIN(cw_max, (cw + 1) * 2);
 	}
 	return t_slot * cw / 2;
 }
@@ -34,22 +40,12 @@ calc_usecs_wifi_packet_tries(int length, int rate, int try0, int tryN)
 	if (!rate || !length || try0 > tryN) {
 		return 99999;
 	}
-
-	/* pg 205 ieee.802.11.pdf */
-	unsigned t_slot = 20;
-	unsigned t_ack = 304; // 192 + 14*8/1
-	unsigned t_difs = 50;
-	unsigned t_sifs = 10;
-
-
-	if (!is_b_rate(rate)) {
-		/* with 802.11g, things are at 6 mbit/s */
-		t_slot = 9;
-		t_sifs = 9;
-		t_difs = 28;
-		t_ack = 30;
+	unsigned t_ack = WIFI_ACK_A;
+	unsigned t_sifs = WIFI_SIFS_A;
+	if (is_b_rate(rate)) {
+		t_ack = WIFI_ACK_B;
+		t_sifs = WIFI_SIFS_B;
 	}
-
 	int tt = 0;
 	for (int x = try0; x <= tryN; x++) {
 		tt += calc_backoff(rate, x) + calc_transmit_time(rate, length) +
@@ -62,6 +58,43 @@ unsigned
 calc_usecs_wifi_packet(int length, int rate, int retries)
 {
 	return calc_usecs_wifi_packet_tries(length, rate, 0, retries);
+}
+
+unsigned
+calc_transmit_time_ht(int rate, int length)
+{
+	return (1000 * length * 8) / mcs_rate_lookup[rate] + WIFI_PLCP_HEADER_N;
+}
+
+unsigned
+calc_backoff_ht(int, int t)
+{
+	int cw = WIFI_CW_MIN;
+	/* there is backoff, even for the first packet */
+	for (int x = 0; x < t; x++) {
+		cw = WIFI_MIN(WIFI_CW_MAX, (cw + 1) * 2);
+	}
+	return WIFI_SLOT_N * cw / 2;
+}
+
+unsigned
+calc_usecs_wifi_packet_tries_ht(int length, int rate, int try0, int tryN)
+{
+	if (rate < 0 || !length || try0 > tryN) {
+		return 99999;
+	}
+	int tt = 0;
+	for (int x = try0; x <= tryN; x++) {
+		tt += calc_backoff_ht(rate, x) + calc_transmit_time_ht(rate, length) +
+			WIFI_SIFS_N + WIFI_ACK_N;
+	}
+	return tt;
+}
+
+unsigned
+calc_usecs_wifi_packet_ht(int length, int rate, int retries)
+{
+	return calc_usecs_wifi_packet_tries_ht(length, rate, 0, retries);
 }
 
 ELEMENT_PROVIDES(bitrate)

--- a/elements/wifi/bitrate.hh
+++ b/elements/wifi/bitrate.hh
@@ -14,4 +14,16 @@ extern unsigned calc_usecs_wifi_packet(int length,
 
 extern unsigned calc_transmit_time(int rate, int length);
 
+extern unsigned calc_usecs_wifi_packet_tries_ht(int length,
+					      int rate,
+					      int try0, int tryN);
+
+extern unsigned calc_backoff_ht(int rate, int t);
+
+extern unsigned calc_usecs_wifi_packet_ht(int length,
+				       int rate, int retries);
+
+
+extern unsigned calc_transmit_time_ht(int rate, int length);
+
 #endif /* _BITRATE_H_ */

--- a/elements/wifi/madwifirate.cc
+++ b/elements/wifi/madwifirate.cc
@@ -192,7 +192,7 @@ MadwifiRate::process_feedback(Packet *p_in)
 
   if (success && (!_alt_rate || !used_alt_rate)) {
     nfo->_successes++;
-    nfo->_retries += ceh->retries;
+    nfo->_retries += ceh->max_tries;
   } else {
     nfo->_failures++;
     nfo->_retries += 4;

--- a/elements/wifi/printtxfeedback.cc
+++ b/elements/wifi/printtxfeedback.cc
@@ -75,8 +75,7 @@ PrintTXFeedback::simple_action(Packet *p)
   sa << " max_retries " << (int) ceh->max_tries;
   sa << " alt_rate " << (int) ceh->rate1;
   sa << " alt_retries " << (int) ceh->max_tries1;
-  sa << " retries " << (int) ceh->retries;
-  sa << " virt_col " << (int) ceh->virt_col;
+  sa << " retries " << (int) ceh->max_tries;
 
   click_chatter("%s\n", sa.c_str());
 

--- a/elements/wifi/printwifi.cc
+++ b/elements/wifi/printwifi.cc
@@ -540,7 +540,7 @@ PrintWifi::simple_action(Packet *p)
   sa << " ] ";
 
   if (ceh->flags & WIFI_EXTRA_TX) {
-	  sa << " retries " << (int) ceh->retries;
+	  sa << " retries " << (int) ceh->max_tries;
   }
 
  done:

--- a/elements/wifi/probetxrate.cc
+++ b/elements/wifi/probetxrate.cc
@@ -146,7 +146,7 @@ ProbeTXRate::process_feedback(Packet *p_in) {
   EtherAddress dst = EtherAddress(dst_ptr);
   struct click_wifi_extra *ceh = WIFI_EXTRA_ANNO(p_in);
   bool success = !(ceh->flags & WIFI_EXTRA_TX_FAIL);
-  int retries = ceh->retries;
+  int retries = ceh->max_tries;
 
   Timestamp now = Timestamp::now();
 

--- a/elements/wifi/radiotap.c
+++ b/elements/wifi/radiotap.c
@@ -1,0 +1,396 @@
+/*
+ * Radiotap parser
+ *
+ * Copyright 2007		Andy Green <andy@warmcat.com>
+ * Copyright 2009		Johannes Berg <johannes@sipsolutions.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * Alternatively, this software may be distributed under the terms of BSD
+ * license.
+ *
+ * See COPYING for more details.
+ */
+#include <click/config.h>
+#include <click/radiotap_iter.h>
+#include <click/platform.h>
+
+/* function prototypes and related defs are in radiotap_iter.h */
+
+static const struct radiotap_align_size rtap_namespace_sizes[] = {
+	[IEEE80211_RADIOTAP_TSFT] = { .align = 8, .size = 8, },
+	[IEEE80211_RADIOTAP_FLAGS] = { .align = 1, .size = 1, },
+	[IEEE80211_RADIOTAP_RATE] = { .align = 1, .size = 1, },
+	[IEEE80211_RADIOTAP_CHANNEL] = { .align = 2, .size = 4, },
+	[IEEE80211_RADIOTAP_FHSS] = { .align = 2, .size = 2, },
+	[IEEE80211_RADIOTAP_DBM_ANTSIGNAL] = { .align = 1, .size = 1, },
+	[IEEE80211_RADIOTAP_DBM_ANTNOISE] = { .align = 1, .size = 1, },
+	[IEEE80211_RADIOTAP_LOCK_QUALITY] = { .align = 2, .size = 2, },
+	[IEEE80211_RADIOTAP_TX_ATTENUATION] = { .align = 2, .size = 2, },
+	[IEEE80211_RADIOTAP_DB_TX_ATTENUATION] = { .align = 2, .size = 2, },
+	[IEEE80211_RADIOTAP_DBM_TX_POWER] = { .align = 1, .size = 1, },
+	[IEEE80211_RADIOTAP_ANTENNA] = { .align = 1, .size = 1, },
+	[IEEE80211_RADIOTAP_DB_ANTSIGNAL] = { .align = 1, .size = 1, },
+	[IEEE80211_RADIOTAP_DB_ANTNOISE] = { .align = 1, .size = 1, },
+	[IEEE80211_RADIOTAP_RX_FLAGS] = { .align = 2, .size = 2, },
+	[IEEE80211_RADIOTAP_TX_FLAGS] = { .align = 2, .size = 2, },
+	[IEEE80211_RADIOTAP_RTS_RETRIES] = { .align = 1, .size = 1, },
+	[IEEE80211_RADIOTAP_DATA_RETRIES] = { .align = 1, .size = 1, },
+	[IEEE80211_RADIOTAP_MCS] = { .align = 1, .size = 3, },
+	[IEEE80211_RADIOTAP_AMPDU_STATUS] = { .align = 4, .size = 8, },
+	/*
+	 * add more here as they are defined in radiotap.h
+	 */
+};
+
+static const struct ieee80211_radiotap_namespace radiotap_ns = {
+	.n_bits = sizeof(rtap_namespace_sizes) / sizeof(rtap_namespace_sizes[0]),
+	.align_size = rtap_namespace_sizes,
+};
+
+/**
+ * ieee80211_radiotap_iterator_init - radiotap parser iterator initialization
+ * @iterator: radiotap_iterator to initialize
+ * @radiotap_header: radiotap header to parse
+ * @max_length: total length we can parse into (eg, whole packet length)
+ *
+ * Returns: 0 or a negative error code if there is a problem.
+ *
+ * This function initializes an opaque iterator struct which can then
+ * be passed to ieee80211_radiotap_iterator_next() to visit every radiotap
+ * argument which is present in the header.  It knows about extended
+ * present headers and handles them.
+ *
+ * How to use:
+ * call __ieee80211_radiotap_iterator_init() to init a semi-opaque iterator
+ * struct ieee80211_radiotap_iterator (no need to init the struct beforehand)
+ * checking for a good 0 return code.  Then loop calling
+ * __ieee80211_radiotap_iterator_next()... it returns either 0,
+ * -ENOENT if there are no more args to parse, or -EINVAL if there is a problem.
+ * The iterator's @this_arg member points to the start of the argument
+ * associated with the current argument index that is present, which can be
+ * found in the iterator's @this_arg_index member.  This arg index corresponds
+ * to the IEEE80211_RADIOTAP_... defines.
+ *
+ * Radiotap header length:
+ * You can find the CPU-endian total radiotap header length in
+ * iterator->max_length after executing ieee80211_radiotap_iterator_init()
+ * successfully.
+ *
+ * Alignment Gotcha:
+ * You must take care when dereferencing iterator.this_arg
+ * for multibyte types... the pointer is not aligned.  Use
+ * get_unaligned((type *)iterator.this_arg) to dereference
+ * iterator.this_arg for type "type" safely on all arches.
+ *
+ * Example code: parse.c
+ */
+
+int ieee80211_radiotap_iterator_init(
+	struct ieee80211_radiotap_iterator *iterator,
+	struct ieee80211_radiotap_header *radiotap_header,
+	int max_length, const struct ieee80211_radiotap_vendor_namespaces *vns)
+{
+	/* must at least have the radiotap header */
+	if (max_length < (int)sizeof(struct ieee80211_radiotap_header))
+		return -EINVAL;
+
+	/* Linux only supports version 0 radiotap format */
+	if (radiotap_header->it_version)
+		return -EINVAL;
+
+	/* sanity check for allowed length and radiotap length field */
+	if (max_length < get_unaligned_le16(&radiotap_header->it_len))
+		return -EINVAL;
+
+	iterator->_rtheader = radiotap_header;
+	iterator->_max_length = get_unaligned_le16(&radiotap_header->it_len);
+	iterator->_arg_index = 0;
+	iterator->_bitmap_shifter = get_unaligned_le32(&radiotap_header->it_present);
+	iterator->_arg = (uint8_t *)radiotap_header + sizeof(*radiotap_header);
+	iterator->_reset_on_ext = 0;
+	iterator->_next_bitmap = &radiotap_header->it_present;
+	iterator->_next_bitmap++;
+	iterator->_vns = vns;
+	iterator->current_namespace = &radiotap_ns;
+	iterator->is_radiotap_ns = 1;
+#ifdef RADIOTAP_SUPPORT_OVERRIDES
+	iterator->n_overrides = 0;
+	iterator->overrides = NULL;
+#endif
+
+	/* find payload start allowing for extended bitmap(s) */
+
+	if (iterator->_bitmap_shifter & (1<<IEEE80211_RADIOTAP_EXT)) {
+		if ((unsigned long)iterator->_arg -
+		    (unsigned long)iterator->_rtheader + sizeof(uint32_t) >
+		    (unsigned long)iterator->_max_length)
+			return -EINVAL;
+		while (get_unaligned_le32(iterator->_arg) &
+					(1 << IEEE80211_RADIOTAP_EXT)) {
+			iterator->_arg += sizeof(uint32_t);
+
+			/*
+			 * check for insanity where the present bitmaps
+			 * keep claiming to extend up to or even beyond the
+			 * stated radiotap header length
+			 */
+
+			if ((unsigned long)iterator->_arg -
+			    (unsigned long)iterator->_rtheader +
+			    sizeof(uint32_t) >
+			    (unsigned long)iterator->_max_length)
+				return -EINVAL;
+		}
+
+		iterator->_arg += sizeof(uint32_t);
+
+		/*
+		 * no need to check again for blowing past stated radiotap
+		 * header length, because ieee80211_radiotap_iterator_next
+		 * checks it before it is dereferenced
+		 */
+	}
+
+	iterator->this_arg = iterator->_arg;
+
+	/* we are all initialized happily */
+
+	return 0;
+}
+
+static void find_ns(struct ieee80211_radiotap_iterator *iterator,
+		    uint32_t oui, uint8_t subns)
+{
+	int i;
+
+	iterator->current_namespace = NULL;
+
+	if (!iterator->_vns)
+		return;
+
+	for (i = 0; i < iterator->_vns->n_ns; i++) {
+		if (iterator->_vns->ns[i].oui != oui)
+			continue;
+		if (iterator->_vns->ns[i].subns != subns)
+			continue;
+
+		iterator->current_namespace = &iterator->_vns->ns[i];
+		break;
+	}
+}
+
+#ifdef RADIOTAP_SUPPORT_OVERRIDES
+static int find_override(struct ieee80211_radiotap_iterator *iterator,
+			 int *align, int *size)
+{
+	int i;
+
+	if (!iterator->overrides)
+		return 0;
+
+	for (i = 0; i < iterator->n_overrides; i++) {
+		if (iterator->_arg_index == iterator->overrides[i].field) {
+			*align = iterator->overrides[i].align;
+			*size = iterator->overrides[i].size;
+			if (!*align) /* erroneous override */
+				return 0;
+			return 1;
+		}
+	}
+
+	return 0;
+}
+#endif
+
+
+/**
+ * ieee80211_radiotap_iterator_next - return next radiotap parser iterator arg
+ * @iterator: radiotap_iterator to move to next arg (if any)
+ *
+ * Returns: 0 if there is an argument to handle,
+ * -ENOENT if there are no more args or -EINVAL
+ * if there is something else wrong.
+ *
+ * This function provides the next radiotap arg index (IEEE80211_RADIOTAP_*)
+ * in @this_arg_index and sets @this_arg to point to the
+ * payload for the field.  It takes care of alignment handling and extended
+ * present fields.  @this_arg can be changed by the caller (eg,
+ * incremented to move inside a compound argument like
+ * IEEE80211_RADIOTAP_CHANNEL).  The args pointed to are in
+ * little-endian format whatever the endianess of your CPU.
+ *
+ * Alignment Gotcha:
+ * You must take care when dereferencing iterator.this_arg
+ * for multibyte types... the pointer is not aligned.  Use
+ * get_unaligned((type *)iterator.this_arg) to dereference
+ * iterator.this_arg for type "type" safely on all arches.
+ */
+
+int ieee80211_radiotap_iterator_next(
+	struct ieee80211_radiotap_iterator *iterator)
+{
+	while (1) {
+		int hit = 0;
+		int pad, align, size, subns;
+		uint32_t oui;
+
+		/* if no more EXT bits, that's it */
+		if ((iterator->_arg_index % 32) == IEEE80211_RADIOTAP_EXT &&
+		    !(iterator->_bitmap_shifter & 1))
+			return -ENOENT;
+
+		if (!(iterator->_bitmap_shifter & 1))
+			goto next_entry; /* arg not present */
+
+		/* get alignment/size of data */
+		switch (iterator->_arg_index % 32) {
+		case IEEE80211_RADIOTAP_RADIOTAP_NAMESPACE:
+		case IEEE80211_RADIOTAP_EXT:
+			align = 1;
+			size = 0;
+			break;
+		case IEEE80211_RADIOTAP_VENDOR_NAMESPACE:
+			align = 2;
+			size = 6;
+			break;
+		default:
+#ifdef RADIOTAP_SUPPORT_OVERRIDES
+			if (find_override(iterator, &align, &size)) {
+				/* all set */
+			} else
+#endif
+			if (!iterator->current_namespace ||
+			    iterator->_arg_index >= iterator->current_namespace->n_bits) {
+				if (iterator->current_namespace == &radiotap_ns)
+					return -ENOENT;
+				align = 0;
+			} else {
+				align = iterator->current_namespace->align_size[iterator->_arg_index].align;
+				size = iterator->current_namespace->align_size[iterator->_arg_index].size;
+			}
+			if (!align) {
+				/* skip all subsequent data */
+				iterator->_arg = iterator->_next_ns_data;
+				/* give up on this namespace */
+				iterator->current_namespace = NULL;
+				goto next_entry;
+			}
+			break;
+		}
+
+		/*
+		 * arg is present, account for alignment padding
+		 *
+		 * Note that these alignments are relative to the start
+		 * of the radiotap header.  There is no guarantee
+		 * that the radiotap header itself is aligned on any
+		 * kind of boundary.
+		 *
+		 * The above is why get_unaligned() is used to dereference
+		 * multibyte elements from the radiotap area.
+		 */
+
+		pad = ((unsigned long)iterator->_arg -
+		       (unsigned long)iterator->_rtheader) & (align - 1);
+
+		if (pad)
+			iterator->_arg += align - pad;
+
+		if (iterator->_arg_index % 32 == IEEE80211_RADIOTAP_VENDOR_NAMESPACE) {
+			int vnslen;
+
+			if ((unsigned long)iterator->_arg + size -
+			    (unsigned long)iterator->_rtheader >
+			    (unsigned long)iterator->_max_length)
+				return -EINVAL;
+
+			oui = (*iterator->_arg << 16) |
+				(*(iterator->_arg + 1) << 8) |
+				*(iterator->_arg + 2);
+			subns = *(iterator->_arg + 3);
+
+			find_ns(iterator, oui, subns);
+
+			vnslen = get_unaligned_le16(iterator->_arg + 4);
+			iterator->_next_ns_data = iterator->_arg + size + vnslen;
+			if (!iterator->current_namespace)
+				size += vnslen;
+		}
+
+		/*
+		 * this is what we will return to user, but we need to
+		 * move on first so next call has something fresh to test
+		 */
+		iterator->this_arg_index = iterator->_arg_index;
+		iterator->this_arg = iterator->_arg;
+		iterator->this_arg_size = size;
+
+		/* internally move on the size of this arg */
+		iterator->_arg += size;
+
+		/*
+		 * check for insanity where we are given a bitmap that
+		 * claims to have more arg content than the length of the
+		 * radiotap section.  We will normally end up equalling this
+		 * max_length on the last arg, never exceeding it.
+		 */
+
+		if ((unsigned long)iterator->_arg -
+		    (unsigned long)iterator->_rtheader >
+		    (unsigned long)iterator->_max_length)
+			return -EINVAL;
+
+		/* these special ones are valid in each bitmap word */
+		switch (iterator->_arg_index % 32) {
+		case IEEE80211_RADIOTAP_VENDOR_NAMESPACE:
+			iterator->_reset_on_ext = 1;
+
+			iterator->is_radiotap_ns = 0;
+			/*
+			 * If parser didn't register this vendor
+			 * namespace with us, allow it to show it
+			 * as 'raw. Do do that, set argument index
+			 * to vendor namespace.
+			 */
+			iterator->this_arg_index =
+				IEEE80211_RADIOTAP_VENDOR_NAMESPACE;
+			if (!iterator->current_namespace)
+				hit = 1;
+			goto next_entry;
+		case IEEE80211_RADIOTAP_RADIOTAP_NAMESPACE:
+			iterator->_reset_on_ext = 1;
+			iterator->current_namespace = &radiotap_ns;
+			iterator->is_radiotap_ns = 1;
+			goto next_entry;
+		case IEEE80211_RADIOTAP_EXT:
+			/*
+			 * bit 31 was set, there is more
+			 * -- move to next u32 bitmap
+			 */
+			iterator->_bitmap_shifter =
+				get_unaligned_le32(iterator->_next_bitmap);
+			iterator->_next_bitmap++;
+			if (iterator->_reset_on_ext)
+				iterator->_arg_index = 0;
+			else
+				iterator->_arg_index++;
+			iterator->_reset_on_ext = 0;
+			break;
+		default:
+			/* we've got a hit! */
+			hit = 1;
+ next_entry:
+			iterator->_bitmap_shifter >>= 1;
+			iterator->_arg_index++;
+		}
+
+		/* if we found a valid arg earlier, return it now */
+		if (hit)
+			return 0;
+	}
+}
+
+ELEMENT_PROVIDES(radiotap)

--- a/elements/wifi/radiotapdecap.cc
+++ b/elements/wifi/radiotapdecap.cc
@@ -18,89 +18,18 @@
 #include <click/config.h>
 #include "radiotapdecap.hh"
 #include <click/etheraddress.hh>
-#include <click/args.hh>
 #include <click/error.hh>
 #include <click/glue.hh>
+#include <click/packet_anno.hh>
 #include <clicknet/wifi.h>
 #include <clicknet/radiotap.h>
-#include <click/packet_anno.hh>
 #include <clicknet/llc.h>
+extern "C" {
+	#include <click/radiotap_iter.h>
+}
 CLICK_DECLS
 
-#define NUM_RADIOTAP_ELEMENTS 22
-
-static const int radiotap_elem_to_bytes[NUM_RADIOTAP_ELEMENTS] =
-	{8, /* IEEE80211_RADIOTAP_TSFT */
-	 1, /* IEEE80211_RADIOTAP_FLAGS */
-	 1, /* IEEE80211_RADIOTAP_RATE */
-	 4, /* IEEE80211_RADIOTAP_CHANNEL */
-	 2, /* IEEE80211_RADIOTAP_FHSS */
-	 1, /* IEEE80211_RADIOTAP_DBM_ANTSIGNAL */
-	 1, /* IEEE80211_RADIOTAP_DBM_ANTNOISE */
-	 2, /* IEEE80211_RADIOTAP_LOCK_QUALITY */
-	 2, /* IEEE80211_RADIOTAP_TX_ATTENUATION */
-	 2, /* IEEE80211_RADIOTAP_DB_TX_ATTENUATION */
-	 1, /* IEEE80211_RADIOTAP_DBM_TX_POWER */
-	 1, /* IEEE80211_RADIOTAP_ANTENNA */
-	 1, /* IEEE80211_RADIOTAP_DB_ANTSIGNAL */
-	 1, /* IEEE80211_RADIOTAP_DB_ANTNOISE */
-	 2, /* IEEE80211_RADIOTAP_RX_FLAGS */
-	 2, /* IEEE80211_RADIOTAP_TX_FLAGS */
-	 1, /* IEEE80211_RADIOTAP_RTS_RETRIES */
-	 1, /* IEEE80211_RADIOTAP_DATA_RETRIES */
-	 8, /* IEEE80211_RADIOTAP_XCHANNEL */
-	 3, /* IEEE80211_RADIOTAP_MCS */
-	 8, /* IEEE80211_RADIOTAP_A_MPDU_STATUS */
-	 12, /* IEEE80211_RADIOTAP_VHT */
-	};
-
-static int rt_el_present(struct ieee80211_radiotap_header *th, u_int32_t element)
-{
-	if (element > NUM_RADIOTAP_ELEMENTS)
-		return 0;
-	return le32_to_cpu(th->it_present) & (1 << element);
-}
-
-static int rt_check_header(struct ieee80211_radiotap_header *th, int len, u_int8_t *offsets[], u_int8_t additional_it_present_flags)
-{
-	int bytes = additional_it_present_flags * sizeof(u_int32_t);
-	bytes += bytes % 8;
-	int x = 0;
-	u_int8_t *ptr = (u_int8_t *)(th + 1);
-
-	if (th->it_version != 0) {
-		return 0;
-	}
-
-	if (le16_to_cpu(th->it_len) < sizeof(struct ieee80211_radiotap_header)) {
-		return 0;
-	}
-
-	for (x = 0; x < NUM_RADIOTAP_ELEMENTS; x++) {
-		if (rt_el_present(th, x)) {
-		    int radiotap_padding_size = radiotap_elem_to_bytes[x];
-		    if(x==IEEE80211_RADIOTAP_CHANNEL) radiotap_padding_size = 2;
-		    int pad = bytes % radiotap_padding_size;
-		    
-		    if (pad)
-			bytes += radiotap_padding_size - pad;
-		    offsets[x] = ptr + bytes;
-		    bytes += radiotap_elem_to_bytes[x];
-		}
-	}
-
-	if (le16_to_cpu(th->it_len) < sizeof(struct ieee80211_radiotap_header) + bytes) {
-		return 0;
-	}
-
-	if (le16_to_cpu(th->it_len) > len) {
-		return 0;
-	}
-
-	return 1;
-}
-
-RadiotapDecap::RadiotapDecap()
+RadiotapDecap::RadiotapDecap() : _debug(false)
 {
 }
 
@@ -108,119 +37,94 @@ RadiotapDecap::~RadiotapDecap()
 {
 }
 
-int
-RadiotapDecap::configure(Vector<String> &conf, ErrorHandler *errh)
-{
-    _debug = false;
-    return Args(conf, this, errh).read("DEBUG", _debug).complete();
-}
-
 Packet *
-RadiotapDecap::simple_action(Packet *p)
-{
-	u_int8_t *offsets[NUM_RADIOTAP_ELEMENTS];
+RadiotapDecap::simple_action(Packet *p) {
+
 	struct ieee80211_radiotap_header *th = (struct ieee80211_radiotap_header *) p->data();
+	struct ieee80211_radiotap_iterator iter;
+	struct click_wifi_extra *ceh = WIFI_EXTRA_ANNO(p);
 
-	u_int8_t additional_it_present_flags = 0;
-	u_int32_t *itpp = (u_int32_t*) &th->it_present;
+	int err = ieee80211_radiotap_iterator_init(&iter, th, p->length(), 0);
 
-	while(le32_to_cpu(*itpp) & (1 << IEEE80211_RADIOTAP_EXT)){
-		additional_it_present_flags++;
-		itpp += 1;
+	if (err) {
+		click_chatter("%{element} :: %s :: malformed radiotap header (init returns %d)", this, __func__, err);
+		goto drop;
 	}
 
-	struct click_wifi_extra *ceh = WIFI_EXTRA_ANNO(p);
-	if (rt_check_header(th, p->length(), offsets, additional_it_present_flags)) {
-		memset((void*)ceh, 0, sizeof(struct click_wifi_extra));
-		ceh->magic = WIFI_EXTRA_MAGIC;
+	memset((void*)ceh, 0, sizeof(struct click_wifi_extra));
+	ceh->magic = WIFI_EXTRA_MAGIC;
 
-		if (rt_el_present(th, IEEE80211_RADIOTAP_FLAGS)) {
-			u_int8_t flags = *offsets[IEEE80211_RADIOTAP_FLAGS];
+	while (!(err = ieee80211_radiotap_iterator_next(&iter))) {
+		u_int16_t flags;
+		switch (iter.this_arg_index) {
+		case IEEE80211_RADIOTAP_TSFT:
+			ceh->tsft = *((uint64_t *)iter.this_arg);
+			break;
+		case IEEE80211_RADIOTAP_FLAGS:
+			flags = le16_to_cpu(*(uint16_t *)iter.this_arg);
 			if (flags & IEEE80211_RADIOTAP_F_DATAPAD) {
 				ceh->pad = 1;
 			}
 			if (flags & IEEE80211_RADIOTAP_F_FCS) {
 				p->take(4);
 			}
-		}
-
-		if (rt_el_present(th, IEEE80211_RADIOTAP_RATE)) {
-			ceh->rate = *offsets[IEEE80211_RADIOTAP_RATE];
-		}
-
-		if (rt_el_present(th, IEEE80211_RADIOTAP_DBM_ANTSIGNAL))
-			ceh->rssi = *offsets[IEEE80211_RADIOTAP_DBM_ANTSIGNAL];
-
-		if (rt_el_present(th, IEEE80211_RADIOTAP_DBM_ANTNOISE))
-			ceh->silence = *offsets[IEEE80211_RADIOTAP_DBM_ANTNOISE];
-
-		if (rt_el_present(th, IEEE80211_RADIOTAP_DB_ANTSIGNAL))
-			ceh->rssi = *offsets[IEEE80211_RADIOTAP_DB_ANTSIGNAL];
-
-		if (rt_el_present(th, IEEE80211_RADIOTAP_DB_ANTNOISE))
-			ceh->silence = *offsets[IEEE80211_RADIOTAP_DB_ANTNOISE];
-
-		if (rt_el_present(th, IEEE80211_RADIOTAP_RX_FLAGS)) {
-			u_int16_t flags = le16_to_cpu(*((u_int16_t *) offsets[IEEE80211_RADIOTAP_RX_FLAGS]));
-			if (flags & IEEE80211_RADIOTAP_F_RX_BADFCS)
+			break;
+		case IEEE80211_RADIOTAP_MCS:
+			ceh->rate = *((uint8_t *)iter.this_arg+2);
+			ceh->flags |= WIFI_EXTRA_MCS;
+			break;
+		case IEEE80211_RADIOTAP_RATE:
+			ceh->rate = *iter.this_arg;
+			break;
+		case IEEE80211_RADIOTAP_DATA_RETRIES:
+			ceh->max_tries = *iter.this_arg + 1;
+			break;
+		case IEEE80211_RADIOTAP_CHANNEL:
+			ceh->channel = le16_to_cpu(*(uint16_t *)iter.this_arg);
+			break;
+		case IEEE80211_RADIOTAP_DBM_ANTSIGNAL:
+			ceh->rssi = *iter.this_arg;
+			break;
+		case IEEE80211_RADIOTAP_DBM_ANTNOISE:
+			ceh->silence = *iter.this_arg;
+			break;
+		case IEEE80211_RADIOTAP_DB_ANTSIGNAL:
+			ceh->rssi = *iter.this_arg;
+			break;
+		case IEEE80211_RADIOTAP_DB_ANTNOISE:
+			ceh->silence = *iter.this_arg;
+			break;
+		case IEEE80211_RADIOTAP_RX_FLAGS:
+			flags = le16_to_cpu(*(uint16_t *)iter.this_arg);
+			if (flags & IEEE80211_RADIOTAP_F_BADFCS)
 				ceh->flags |= WIFI_EXTRA_RX_ERR;
-		}
-
-		if (rt_el_present(th, IEEE80211_RADIOTAP_TX_FLAGS)) {
-			u_int16_t flags = le16_to_cpu(*((u_int16_t *) offsets[IEEE80211_RADIOTAP_TX_FLAGS]));
+			break;
+		case IEEE80211_RADIOTAP_TX_FLAGS:
+			flags = le16_to_cpu(*(uint16_t *)iter.this_arg);
 			ceh->flags |= WIFI_EXTRA_TX;
 			if (flags & IEEE80211_RADIOTAP_F_TX_FAIL)
 				ceh->flags |= WIFI_EXTRA_TX_FAIL;
+			break;
 		}
-
-		if (rt_el_present(th, IEEE80211_RADIOTAP_DATA_RETRIES))
-			ceh->retries = *offsets[IEEE80211_RADIOTAP_DATA_RETRIES];
-
-		p->pull(le16_to_cpu(th->it_len));
-		p->set_mac_header(p->data());  // reset mac-header pointer
 	}
 
-  return p;
+	if (err != -ENOENT) {
+		click_chatter("%{element} :: %s :: malformed radiotap data", this, __func__);
+		goto drop;
+	}
+
+	p->pull(le16_to_cpu(th->it_len));
+	p->set_mac_header(p->data()); // reset mac-header pointer
+
+	return p;
+
+  drop:
+
+	p->kill();
+	return 0;
+
 }
 
-
-enum {H_DEBUG};
-
-static String
-RadiotapDecap_read_param(Element *e, void *thunk)
-{
-  RadiotapDecap *td = (RadiotapDecap *)e;
-    switch ((uintptr_t) thunk) {
-      case H_DEBUG:
-	return String(td->_debug) + "\n";
-    default:
-      return String();
-    }
-}
-static int
-RadiotapDecap_write_param(const String &in_s, Element *e, void *vparam,
-		      ErrorHandler *errh)
-{
-  RadiotapDecap *f = (RadiotapDecap *)e;
-  String s = cp_uncomment(in_s);
-  switch((intptr_t)vparam) {
-  case H_DEBUG: {    //debug
-    bool debug;
-    if (!BoolArg().parse(s, debug))
-      return errh->error("debug parameter must be boolean");
-    f->_debug = debug;
-    break;
-  }
-  }
-  return 0;
-}
-
-void
-RadiotapDecap::add_handlers()
-{
-  add_read_handler("debug", RadiotapDecap_read_param, H_DEBUG);
-
-  add_write_handler("debug", RadiotapDecap_write_param, H_DEBUG);
-}
 CLICK_ENDDECLS
 EXPORT_ELEMENT(RadiotapDecap)
+ELEMENT_REQUIRES(radiotap)

--- a/elements/wifi/radiotapdecap.hh
+++ b/elements/wifi/radiotapdecap.hh
@@ -28,17 +28,10 @@ class RadiotapDecap : public Element { public:
   const char *port_count() const	{ return PORTS_1_1; }
   const char *processing() const	{ return AGNOSTIC; }
 
-  int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
   bool can_live_reconfigure() const	{ return true; }
 
   Packet *simple_action(Packet *);
-
-
-  void add_handlers() CLICK_COLD;
-
-
   bool _debug;
- private:
 
 };
 

--- a/elements/wifi/radiotapencap.cc
+++ b/elements/wifi/radiotapencap.cc
@@ -1,6 +1,6 @@
 /*
  * radiotapencap.{cc,hh} -- encapsultates 802.11 packets
- * John Bicket
+ * John Bicket, Roberto Riggio
  *
  * Copyright (c) 2004 Massachusetts Institute of Technology
  *
@@ -18,7 +18,6 @@
 #include <click/config.h>
 #include "radiotapencap.hh"
 #include <click/etheraddress.hh>
-#include <click/args.hh>
 #include <click/error.hh>
 #include <click/glue.hh>
 #include <clicknet/wifi.h>
@@ -27,118 +26,252 @@
 #include <clicknet/radiotap.h>
 CLICK_DECLS
 
+#define CLICK_RADIOTAP_PRESENT (			          \
+	(1 << IEEE80211_RADIOTAP_RATE)			        | \
+	(1 << IEEE80211_RADIOTAP_TX_FLAGS)    		    | \
+	(1 << IEEE80211_RADIOTAP_DATA_RETRIES)		    | \
+	(1 << IEEE80211_RADIOTAP_RADIOTAP_NAMESPACE)	| \
+	(1 << IEEE80211_RADIOTAP_EXT)			        | \
+	0)
 
-
-#define CLICK_RADIOTAP_PRESENT (		\
-	(1 << IEEE80211_RADIOTAP_RATE)		| \
-	(1 << IEEE80211_RADIOTAP_DBM_TX_POWER)	| \
-	(1 << IEEE80211_RADIOTAP_TX_FLAGS)	| \
-	(1 << IEEE80211_RADIOTAP_DATA_RETRIES)	| \
+#define CLICK_RADIOTAP_PRESENT_HT (			          \
+	(1 << IEEE80211_RADIOTAP_TX_FLAGS)    		    | \
+	(1 << IEEE80211_RADIOTAP_DATA_RETRIES)		    | \
+	(1 << IEEE80211_RADIOTAP_MCS)			        | \
+	(1 << IEEE80211_RADIOTAP_RADIOTAP_NAMESPACE)	| \
+	(1 << IEEE80211_RADIOTAP_EXT)			        | \
 	0)
 
 struct click_radiotap_header {
 	struct ieee80211_radiotap_header wt_ihdr;
+	u_int32_t	it_present1;
+	u_int32_t	it_present2;
+	u_int32_t	it_present3;
+
 	u_int8_t	wt_rate;
-	u_int8_t	wt_txpower;
+	u_int8_t	wt_pad;
 	u_int16_t	wt_tx_flags;
-	u_int8_t        wt_data_retries;
-};
+	u_int8_t	wt_data_retries;
 
+	u_int8_t	wt_rate1;
+	u_int8_t	wt_data_retries1;
 
+	u_int8_t	wt_rate2;
+	u_int8_t	wt_data_retries2;
 
+	u_int8_t	wt_rate3;
+	u_int8_t	wt_data_retries3;
 
+} __attribute__((__packed__));
 
+struct click_radiotap_header_ht {
+	struct ieee80211_radiotap_header wt_ihdr;
+	u_int32_t	it_present1;
+	u_int32_t	it_present2;
+	u_int32_t	it_present3;
 
-RadiotapEncap::RadiotapEncap()
-{
+	u_int16_t	wt_tx_flags;
+	u_int8_t	wt_data_retries;
+	u_int8_t	wt_known;
+	u_int8_t	wt_flags;
+	u_int8_t	wt_mcs;
+
+	u_int8_t	wt_data_retries1;
+	u_int8_t	wt_known1;
+	u_int8_t	wt_flags1;
+	u_int8_t	wt_mcs1;
+
+	u_int8_t	wt_data_retries2;
+	u_int8_t	wt_known2;
+	u_int8_t	wt_flags2;
+	u_int8_t	wt_mcs2;
+
+	u_int8_t	wt_data_retries3;
+	u_int8_t	wt_known3;
+	u_int8_t	wt_flags3;
+	u_int8_t	wt_mcs3;
+} __attribute__((__packed__));
+
+RadiotapEncap::RadiotapEncap() : _debug(false) {
 }
 
-RadiotapEncap::~RadiotapEncap()
-{
-}
-
-int
-RadiotapEncap::configure(Vector<String> &conf, ErrorHandler *errh)
-{
-    _debug = false;
-    return Args(conf, this, errh).read("DEBUG", _debug).complete();
+RadiotapEncap::~RadiotapEncap() {
 }
 
 Packet *
-RadiotapEncap::simple_action(Packet *p)
-{
-
-  WritablePacket *p_out = p->uniqueify();
-  if (!p_out) {
-    p->kill();
-    return 0;
-  }
-
-  p_out = p_out->push(sizeof(struct click_radiotap_header));
-
-  if (p_out) {
-	  struct click_radiotap_header *crh  = (struct click_radiotap_header *) p_out->data();
-	  click_wifi_extra *ceh = WIFI_EXTRA_ANNO(p);
-
-	  memset(crh, 0, sizeof(struct click_radiotap_header));
-
-	  crh->wt_ihdr.it_version = 0;
-	  crh->wt_ihdr.it_len = cpu_to_le16(sizeof(struct click_radiotap_header));
-	  crh->wt_ihdr.it_present = cpu_to_le32(CLICK_RADIOTAP_PRESENT);
-
-	  crh->wt_rate = ceh->rate;
-	  crh->wt_txpower = ceh->power;
-          if (ceh->flags & WIFI_EXTRA_TX_NOACK) {
-                  crh->wt_tx_flags |= IEEE80211_RADIOTAP_F_TX_NOACK;
-          }
-	  if (ceh->max_tries > 0) {
-		  crh->wt_data_retries = ceh->max_tries - 1;
-	  } else {
-		  crh->wt_data_retries = WIFI_MAX_RETRIES + 1;
-	  }
-  }
-
-  return p_out;
+RadiotapEncap::simple_action(Packet *p) {
+	click_wifi_extra *ceh = WIFI_EXTRA_ANNO(p);
+	if (ceh->flags & WIFI_EXTRA_MCS)
+		return encap_ht(p);
+	return encap(p);
 }
 
+Packet *
+RadiotapEncap::encap_ht(Packet *p) {
 
-enum {H_DEBUG};
+	click_wifi_extra *ceh = WIFI_EXTRA_ANNO(p);
+	WritablePacket *p_out = p->uniqueify();
 
-static String
-RadiotapEncap_read_param(Element *e, void *thunk)
-{
-  RadiotapEncap *td = (RadiotapEncap *)e;
-    switch ((uintptr_t) thunk) {
-      case H_DEBUG:
-	return String(td->_debug) + "\n";
-    default:
-      return String();
-    }
+	if (!p_out) {
+		p->kill();
+		return 0;
+	}
+
+	p_out = p_out->push(sizeof(struct click_radiotap_header_ht));
+
+	if (!p_out) {
+		p->kill();
+		return 0;
+	}
+
+	struct click_radiotap_header_ht *crh  = (struct click_radiotap_header_ht *) p_out->data();
+
+	memset(crh, 0, sizeof(struct click_radiotap_header_ht));
+
+	crh->wt_ihdr.it_version = 0;
+	crh->wt_ihdr.it_len = cpu_to_le16(sizeof(struct click_radiotap_header_ht));
+
+	crh->wt_ihdr.it_present = cpu_to_le32(CLICK_RADIOTAP_PRESENT_HT);
+
+	crh->wt_known |= IEEE80211_RADIOTAP_MCS_HAVE_BW | 
+	                 IEEE80211_RADIOTAP_MCS_HAVE_MCS | 
+	                 IEEE80211_RADIOTAP_MCS_HAVE_GI;
+
+	if (ceh->flags & WIFI_EXTRA_MCS_SGI) {
+		crh->wt_flags |= IEEE80211_RADIOTAP_MCS_SGI;
+	}
+
+	if (ceh->flags & WIFI_EXTRA_MCS_BW_40) {
+		crh->wt_flags |= IEEE80211_RADIOTAP_MCS_BW_40;
+	}
+
+	crh->wt_mcs = ceh->rate;
+	crh->wt_data_retries = (ceh->max_tries > 0) ? ceh->max_tries - 1 : WIFI_MAX_RETRIES;
+
+	if (ceh->flags & WIFI_EXTRA_TX_NOACK) {
+		crh->wt_tx_flags |= IEEE80211_RADIOTAP_F_TX_NOACK;
+	}
+
+	crh->it_present1 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_RADIOTAP_NAMESPACE);
+	crh->it_present1 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_EXT);
+	crh->it_present2 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_RADIOTAP_NAMESPACE);
+	crh->it_present2 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_EXT);
+
+	if (ceh->rate1 != -1) {
+		crh->it_present1 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_MCS);
+		crh->it_present1 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_DATA_RETRIES);
+		crh->wt_mcs1 = ceh->rate1;
+		crh->wt_data_retries1 = (ceh->max_tries1 > 0) ? ceh->max_tries1 - 1 : WIFI_MAX_RETRIES;
+		crh->wt_known1 |= IEEE80211_RADIOTAP_MCS_HAVE_BW |
+		                  IEEE80211_RADIOTAP_MCS_HAVE_MCS |
+		                  IEEE80211_RADIOTAP_MCS_HAVE_GI;
+		if (ceh->flags & WIFI_EXTRA_MCS_SGI) {
+			crh->wt_flags1 |= IEEE80211_RADIOTAP_MCS_SGI;
+		}
+
+		if (ceh->flags & WIFI_EXTRA_MCS_BW_40) {
+			crh->wt_flags1 |= IEEE80211_RADIOTAP_MCS_BW_40;
+		}
+		if (ceh->rate2 != -1) {
+			crh->it_present2 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_MCS);
+			crh->it_present2 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_DATA_RETRIES);
+			crh->wt_mcs2 = ceh->rate2;
+			crh->wt_data_retries2 = (ceh->max_tries2 > 0) ? ceh->max_tries2 - 1 : WIFI_MAX_RETRIES;
+			crh->wt_known2 |= IEEE80211_RADIOTAP_MCS_HAVE_BW |
+			                  IEEE80211_RADIOTAP_MCS_HAVE_MCS |
+			                  IEEE80211_RADIOTAP_MCS_HAVE_GI;
+			if (ceh->flags & WIFI_EXTRA_MCS_SGI) {
+				crh->wt_flags2 |= IEEE80211_RADIOTAP_MCS_SGI;
+			}
+
+			if (ceh->flags & WIFI_EXTRA_MCS_BW_40) {
+				crh->wt_flags2 |= IEEE80211_RADIOTAP_MCS_BW_40;
+			}
+			if (ceh->rate3 != -1) {
+				crh->it_present3 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_MCS);
+				crh->it_present3 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_DATA_RETRIES);
+				crh->wt_mcs3 = ceh->rate3;
+				crh->wt_data_retries3 = (ceh->max_tries3 > 0) ? ceh->max_tries3 - 1 : WIFI_MAX_RETRIES;
+				crh->wt_known3 |= IEEE80211_RADIOTAP_MCS_HAVE_BW |
+				                  IEEE80211_RADIOTAP_MCS_HAVE_MCS |
+				                  IEEE80211_RADIOTAP_MCS_HAVE_GI;
+				if (ceh->flags & WIFI_EXTRA_MCS_SGI) {
+					crh->wt_flags3 |= IEEE80211_RADIOTAP_MCS_SGI;
+				}
+
+				if (ceh->flags & WIFI_EXTRA_MCS_BW_40) {
+					crh->wt_flags3 |= IEEE80211_RADIOTAP_MCS_BW_40;
+				}
+			}
+		}
+	}
+
+	return p_out;
+
 }
-static int
-RadiotapEncap_write_param(const String &in_s, Element *e, void *vparam,
-		      ErrorHandler *errh)
-{
-  RadiotapEncap *f = (RadiotapEncap *)e;
-  String s = cp_uncomment(in_s);
-  switch((intptr_t)vparam) {
-  case H_DEBUG: {    //debug
-    bool debug;
-    if (!BoolArg().parse(s, debug))
-      return errh->error("debug parameter must be boolean");
-    f->_debug = debug;
-    break;
-  }
-  }
-  return 0;
+
+Packet *
+RadiotapEncap::encap(Packet *p) {
+
+	click_wifi_extra *ceh = WIFI_EXTRA_ANNO(p);
+	WritablePacket *p_out = p->uniqueify();
+
+	if (!p_out) {
+		p->kill();
+		return 0;
+	}
+
+	p_out = p_out->push(sizeof(struct click_radiotap_header));
+
+	if (!p_out) {
+		p->kill();
+		return 0;
+	}
+
+	struct click_radiotap_header *crh  = (struct click_radiotap_header *) p_out->data();
+
+	memset(crh, 0, sizeof(struct click_radiotap_header));
+
+	crh->wt_ihdr.it_version = 0;
+	crh->wt_ihdr.it_len = cpu_to_le16(sizeof(struct click_radiotap_header));
+
+	crh->wt_ihdr.it_present = cpu_to_le32(CLICK_RADIOTAP_PRESENT);
+
+	crh->wt_rate = ceh->rate;
+	crh->wt_data_retries = (ceh->max_tries > 0) ? ceh->max_tries - 1 : WIFI_MAX_RETRIES;
+
+	if (ceh->flags & WIFI_EXTRA_TX_NOACK) {
+		crh->wt_tx_flags |= IEEE80211_RADIOTAP_F_TX_NOACK;
+	}
+
+	crh->it_present1 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_RADIOTAP_NAMESPACE);
+	crh->it_present1 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_EXT);
+	crh->it_present2 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_RADIOTAP_NAMESPACE);
+	crh->it_present2 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_EXT);
+
+	if (ceh->rate1 != -1) {
+		crh->it_present1 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_RATE);
+		crh->it_present1 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_DATA_RETRIES);
+		crh->wt_rate1 = ceh->rate1;
+		crh->wt_data_retries1 = (ceh->max_tries1 > 0) ? ceh->max_tries1 - 1 : WIFI_MAX_RETRIES;
+		if (ceh->rate2 != -1) {
+			crh->it_present2 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_RATE);
+			crh->it_present2 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_DATA_RETRIES);
+			crh->wt_rate2 = ceh->rate2;
+			crh->wt_data_retries2 = (ceh->max_tries2 > 0) ? ceh->max_tries2 - 1 : WIFI_MAX_RETRIES;
+			if (ceh->rate3 != -1) {
+				crh->it_present3 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_RATE);
+				crh->it_present3 |= cpu_to_le32(1 << IEEE80211_RADIOTAP_DATA_RETRIES);
+				crh->wt_rate3 = ceh->rate3;
+				crh->wt_data_retries3 = (ceh->max_tries3 > 0) ? ceh->max_tries3 - 1 : WIFI_MAX_RETRIES;
+			}
+		}
+	}
+
+	return p_out;
+
 }
 
-void
-RadiotapEncap::add_handlers()
-{
-  add_read_handler("debug", RadiotapEncap_read_param, H_DEBUG);
-
-  add_write_handler("debug", RadiotapEncap_write_param, H_DEBUG);
-}
 CLICK_ENDDECLS
 EXPORT_ELEMENT(RadiotapEncap)
+ELEMENT_REQUIRES(radiotap)

--- a/elements/wifi/radiotapencap.hh
+++ b/elements/wifi/radiotapencap.hh
@@ -29,17 +29,13 @@ class RadiotapEncap : public Element { public:
   const char *port_count() const	{ return PORTS_1_1; }
   const char *processing() const	{ return AGNOSTIC; }
 
-  int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
   bool can_live_reconfigure() const	{ return true; }
 
   Packet *simple_action(Packet *);
-
-
-  void add_handlers() CLICK_COLD;
-
+  Packet *encap(Packet *);
+  Packet *encap_ht(Packet *);
 
   bool _debug;
- private:
 
 };
 

--- a/elements/wifi/settxrateht.hh
+++ b/elements/wifi/settxrateht.hh
@@ -1,12 +1,12 @@
-#ifndef CLICK_SETTXRATE_HH
-#define CLICK_SETTXRATE_HH
+#ifndef CLICK_SETTXRATEHT_HH
+#define CLICK_SETTXRATEHT_HH
 #include <click/element.hh>
 #include <click/glue.hh>
 CLICK_DECLS
 
 /*
 =c
-SetTXRate([I<KEYWORDS>])
+SetTXRateHT([I<KEYWORDS>])
 
 =s Wifi
 
@@ -19,9 +19,8 @@ Sets the Wifi TXRate Annotation on a packet.
 Regular Arguments:
 =over 8
 
-=item RATE
-Unsigned integer. Rate value is multiplied by 2 (i.e. 2
-means 1 Mbps, 11 means 5.5 Mbps)
+=item MCS
+Unsigned integer. MCS index.
 
 =back 8
 
@@ -31,13 +30,13 @@ Same as RATE Argument
 =a AutoRateFallback, MadwifiRate, ProbeRate, ExtraEncap
 */
 
-class SetTXRate: public Element {
+class SetTXRateHT: public Element {
 public:
 
-	SetTXRate() CLICK_COLD;
-	~SetTXRate() CLICK_COLD;
+	SetTXRateHT() CLICK_COLD;
+	~SetTXRateHT() CLICK_COLD;
 
-	const char *class_name() const { return "SetTXRate"; }
+	const char *class_name() const { return "SetTXRateHT"; }
 	const char *port_count() const { return PORTS_1_1; }
 	const char *processing() const { return AGNOSTIC; }
 
@@ -53,10 +52,10 @@ public:
 
 private:
 
-	int _rate;
-	int _rate1;
-	int _rate2;
-	int _rate3;
+	int _mcs;
+	int _mcs1;
+	int _mcs2;
+	int _mcs3;
 
 	unsigned _max_tries;
 	unsigned _max_tries1;
@@ -65,6 +64,8 @@ private:
 
 	uint16_t _et;
 	unsigned _offset;
+	bool _sgi;
+	bool _bw_40;
 
 };
 

--- a/include/click/packet_anno.hh
+++ b/include/click/packet_anno.hh
@@ -13,7 +13,7 @@
 
 // bytes 16-31
 #define WIFI_EXTRA_ANNO_OFFSET		16
-#define WIFI_EXTRA_ANNO_SIZE		24
+#define WIFI_EXTRA_ANNO_SIZE		28
 #define WIFI_EXTRA_ANNO(p)		((click_wifi_extra *) ((p)->anno_u8() + WIFI_EXTRA_ANNO_OFFSET))
 
 // byte 16

--- a/include/click/platform.h
+++ b/include/click/platform.h
@@ -1,0 +1,25 @@
+#include <stddef.h>
+#include <errno.h>
+#ifndef _BSD_SOURCE
+#define _BSD_SOURCE
+#endif
+#include <endian.h>
+
+#if !defined(le32toh) || !defined(le16toh)
+#    include <byteswap.h>
+#    define le32toh(x) bswap_32(x)
+#    define le16toh(x) bswap_16(x)
+#endif
+
+#define le16_to_cpu		le16toh
+#define le32_to_cpu		le32toh
+#define get_unaligned(p)					\
+({								\
+	struct packed_dummy_struct {				\
+		typeof(*(p)) __val;				\
+	} __attribute__((packed)) *__ptr = (void *) (p);	\
+								\
+	__ptr->__val;						\
+})
+#define get_unaligned_le16(p)	le16_to_cpu(get_unaligned((uint16_t *)(p)))
+#define get_unaligned_le32(p)	le32_to_cpu(get_unaligned((uint32_t *)(p)))

--- a/include/click/radiotap_iter.h
+++ b/include/click/radiotap_iter.h
@@ -1,0 +1,94 @@
+#ifndef CLICK_RADIOTAP_ITER_H
+#define CLICK_RADIOTAP_ITER_H
+
+#include <stdint.h>
+#include <clicknet/radiotap.h>
+
+/* Radiotap header iteration
+ *   implemented in radiotap.c
+ */
+
+struct radiotap_override {
+	uint8_t field;
+	uint8_t align:4, size:4;
+};
+
+struct radiotap_align_size {
+	uint8_t align:4, size:4;
+};
+
+struct ieee80211_radiotap_namespace {
+	const struct radiotap_align_size *align_size;
+	int n_bits;
+	uint32_t oui;
+	uint8_t subns;
+};
+
+struct ieee80211_radiotap_vendor_namespaces {
+	const struct ieee80211_radiotap_namespace *ns;
+	int n_ns;
+};
+
+/**
+ * struct ieee80211_radiotap_iterator - tracks walk thru present radiotap args
+ * @this_arg_index: index of current arg, valid after each successful call
+ *	to ieee80211_radiotap_iterator_next()
+ * @this_arg: pointer to current radiotap arg; it is valid after each
+ *	call to ieee80211_radiotap_iterator_next() but also after
+ *	ieee80211_radiotap_iterator_init() where it will point to
+ *	the beginning of the actual data portion
+ * @this_arg_size: length of the current arg, for convenience
+ * @current_namespace: pointer to the current namespace definition
+ *	(or internally %NULL if the current namespace is unknown)
+ * @is_radiotap_ns: indicates whether the current namespace is the default
+ *	radiotap namespace or not
+ *
+ * @overrides: override standard radiotap fields
+ * @n_overrides: number of overrides
+ *
+ * @_rtheader: pointer to the radiotap header we are walking through
+ * @_max_length: length of radiotap header in cpu byte ordering
+ * @_arg_index: next argument index
+ * @_arg: next argument pointer
+ * @_next_bitmap: internal pointer to next present u32
+ * @_bitmap_shifter: internal shifter for curr u32 bitmap, b0 set == arg present
+ * @_vns: vendor namespace definitions
+ * @_next_ns_data: beginning of the next namespace's data
+ * @_reset_on_ext: internal; reset the arg index to 0 when going to the
+ *	next bitmap word
+ *
+ * Describes the radiotap parser state. Fields prefixed with an underscore
+ * must not be used by users of the parser, only by the parser internally.
+ */
+
+struct ieee80211_radiotap_iterator {
+	struct ieee80211_radiotap_header *_rtheader;
+	const struct ieee80211_radiotap_vendor_namespaces *_vns;
+	const struct ieee80211_radiotap_namespace *current_namespace;
+
+	unsigned char *_arg, *_next_ns_data;
+	uint32_t *_next_bitmap;
+
+	unsigned char *this_arg;
+	const struct radiotap_override *overrides;	/* Only for RADIOTAP_SUPPORT_OVERRIDES */
+	int n_overrides;				/* Only for RADIOTAP_SUPPORT_OVERRIDES */
+	int this_arg_index;
+	int this_arg_size;
+
+	int is_radiotap_ns;
+
+	int _max_length;
+	int _arg_index;
+	uint32_t _bitmap_shifter;
+	int _reset_on_ext;
+};
+
+extern int ieee80211_radiotap_iterator_init(
+	struct ieee80211_radiotap_iterator *iterator,
+	struct ieee80211_radiotap_header *radiotap_header,
+	int max_length, const struct ieee80211_radiotap_vendor_namespaces *vns);
+
+extern int ieee80211_radiotap_iterator_next(
+	struct ieee80211_radiotap_iterator *iterator);
+
+#endif /* CLICK_RADIOTAP_ITER_H */

--- a/include/clicknet/radiotap.h
+++ b/include/clicknet/radiotap.h
@@ -1,6 +1,3 @@
-/* $FreeBSD: src/sys/net80211/ieee80211_radiotap.h,v 1.5 2005/01/22 20:12:05 sam Exp $ */
-/* $NetBSD: ieee80211_radiotap.h,v 1.10 2005/01/04 00:34:58 dyoung Exp $ */
-
 /*-
  * Copyright (c) 2003, 2004 David Young.  All rights reserved.
  *
@@ -29,8 +26,19 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
  * OF SUCH DAMAGE.
  */
-#ifndef _NET_IF_IEEE80211RADIOTAP_H_
-#define _NET_IF_IEEE80211RADIOTAP_H_
+
+/*
+ * Modifications to fit into the linux IEEE 802.11 stack,
+ * Mike Kershaw (dragorn@kismetwireless.net)
+ */
+
+#ifndef IEEE80211RADIOTAP_H
+#define IEEE80211RADIOTAP_H
+
+#include <stdint.h>
+
+/* Base version of the radiotap packet header data */
+#define PKTHDR_RADIOTAP_VERSION		0
 
 /* A generic radio capture format is desirable. There is one for
  * Linux, but it is neither rigidly defined (there were not even
@@ -46,135 +54,135 @@
  * function of...") that I cannot set false expectations for lawyerly
  * readers.
  */
-#if defined(__KERNEL__) || defined(_KERNEL)
-#ifndef DLT_IEEE802_11_RADIO
-#define	DLT_IEEE802_11_RADIO	127	/* 802.11 plus WLAN header */
-#endif
-#endif /* defined(__KERNEL__) || defined(_KERNEL) */
 
-/* XXX tcpdump/libpcap do not tolerate variable-length headers,
- * yet, so we pad every radiotap header to 64 bytes. Ugh.
+/* The radio capture header precedes the 802.11 header.
+ * All data in the header is little endian on all platforms.
  */
-#define IEEE80211_RADIOTAP_HDRLEN	64
-
-/* The radio capture header precedes the 802.11 header. */
 struct ieee80211_radiotap_header {
-	u_int8_t	it_version;	/* Version 0. Only increases
-					 * for drastic changes,
-					 * introduction of compatible
-					 * new fields does not count.
-					 */
-	u_int8_t	it_pad;
-	u_int16_t       it_len;         /* length of the whole
-					 * header in bytes, including
-					 * it_version, it_pad,
-					 * it_len, and data fields.
-					 */
-	u_int32_t       it_present;     /* A bitmap telling which
-					 * fields are present. Set bit 31
-					 * (0x80000000) to extend the
-					 * bitmap by another 32 bits.
-					 * Additional extensions are made
-					 * by setting bit 31.
-					 */
+	uint8_t it_version;	/* Version 0. Only increases
+				 * for drastic changes,
+				 * introduction of compatible
+				 * new fields does not count.
+				 */
+	uint8_t it_pad;
+	uint16_t it_len;	/* length of the whole
+				 * header in bytes, including
+				 * it_version, it_pad,
+				 * it_len, and data fields.
+				 */
+	uint32_t it_present;	/* A bitmap telling which
+				 * fields are present. Set bit 31
+				 * (0x80000000) to extend the
+				 * bitmap by another 32 bits.
+				 * Additional extensions are made
+				 * by setting bit 31.
+				 */
 } __attribute__((__packed__));
 
-/* Name                                 Data type       Units
- * ----                                 ---------       -----
+/* Name                                 Data type    Units
+ * ----                                 ---------    -----
  *
- * IEEE80211_RADIOTAP_TSFT              u_int64_t       microseconds
+ * IEEE80211_RADIOTAP_TSFT              __le64       microseconds
  *
  *      Value in microseconds of the MAC's 64-bit 802.11 Time
  *      Synchronization Function timer when the first bit of the
  *      MPDU arrived at the MAC. For received frames, only.
  *
- * IEEE80211_RADIOTAP_CHANNEL           2 x u_int16_t   MHz, bitmap
+ * IEEE80211_RADIOTAP_CHANNEL           2 x uint16_t   MHz, bitmap
  *
  *      Tx/Rx frequency in MHz, followed by flags (see below).
  *
- * IEEE80211_RADIOTAP_FHSS              u_int16_t       see below
+ * IEEE80211_RADIOTAP_FHSS              uint16_t       see below
  *
  *      For frequency-hopping radios, the hop set (first byte)
  *      and pattern (second byte).
  *
- * IEEE80211_RADIOTAP_RATE              u_int8_t        500kb/s
+ * IEEE80211_RADIOTAP_RATE              u8           500kb/s
  *
  *      Tx/Rx data rate
  *
- * IEEE80211_RADIOTAP_DBM_ANTSIGNAL     int8_t          decibels from
- *                                                      one milliwatt (dBm)
+ * IEEE80211_RADIOTAP_DBM_ANTSIGNAL     s8           decibels from
+ *                                                   one milliwatt (dBm)
  *
  *      RF signal power at the antenna, decibel difference from
  *      one milliwatt.
  *
- * IEEE80211_RADIOTAP_DBM_ANTNOISE      int8_t          decibels from
- *                                                      one milliwatt (dBm)
+ * IEEE80211_RADIOTAP_DBM_ANTNOISE      s8           decibels from
+ *                                                   one milliwatt (dBm)
  *
  *      RF noise power at the antenna, decibel difference from one
  *      milliwatt.
  *
- * IEEE80211_RADIOTAP_DB_ANTSIGNAL      u_int8_t        decibel (dB)
+ * IEEE80211_RADIOTAP_DB_ANTSIGNAL      u8           decibel (dB)
  *
  *      RF signal power at the antenna, decibel difference from an
  *      arbitrary, fixed reference.
  *
- * IEEE80211_RADIOTAP_DB_ANTNOISE       u_int8_t        decibel (dB)
+ * IEEE80211_RADIOTAP_DB_ANTNOISE       u8           decibel (dB)
  *
  *      RF noise power at the antenna, decibel difference from an
  *      arbitrary, fixed reference point.
  *
- * IEEE80211_RADIOTAP_LOCK_QUALITY      u_int16_t       unitless
+ * IEEE80211_RADIOTAP_LOCK_QUALITY      uint16_t       unitless
  *
  *      Quality of Barker code lock. Unitless. Monotonically
  *      nondecreasing with "better" lock strength. Called "Signal
  *      Quality" in datasheets.  (Is there a standard way to measure
  *      this?)
  *
- * IEEE80211_RADIOTAP_TX_ATTENUATION    u_int16_t       unitless
+ * IEEE80211_RADIOTAP_TX_ATTENUATION    uint16_t       unitless
  *
  *      Transmit power expressed as unitless distance from max
  *      power set at factory calibration.  0 is max power.
  *      Monotonically nondecreasing with lower power levels.
  *
- * IEEE80211_RADIOTAP_DB_TX_ATTENUATION u_int16_t       decibels (dB)
+ * IEEE80211_RADIOTAP_DB_TX_ATTENUATION uint16_t       decibels (dB)
  *
  *      Transmit power expressed as decibel distance from max power
  *      set at factory calibration.  0 is max power.  Monotonically
  *      nondecreasing with lower power levels.
  *
- * IEEE80211_RADIOTAP_DBM_TX_POWER      int8_t          decibels from
- *                                                      one milliwatt (dBm)
+ * IEEE80211_RADIOTAP_DBM_TX_POWER      s8           decibels from
+ *                                                   one milliwatt (dBm)
  *
  *      Transmit power expressed as dBm (decibels from a 1 milliwatt
  *      reference). This is the absolute power level measured at
  *      the antenna port.
  *
- * IEEE80211_RADIOTAP_FLAGS             u_int8_t        bitmap
+ * IEEE80211_RADIOTAP_FLAGS             u8           bitmap
  *
  *      Properties of transmitted and received frames. See flags
  *      defined below.
  *
- * IEEE80211_RADIOTAP_ANTENNA           u_int8_t        antenna index
+ * IEEE80211_RADIOTAP_ANTENNA           u8           antenna index
  *
  *      Unitless indication of the Rx/Tx antenna for this packet.
  *      The first antenna is antenna 0.
  *
- * IEEE80211_RADIOTAP_RX_FLAGS          u_int16_t       bitmap
+ * IEEE80211_RADIOTAP_RX_FLAGS          uint16_t       bitmap
  *
- *	Properties of received frames. See flags defined below.
+ *     Properties of received frames. See flags defined below.
  *
- * IEEE80211_RADIOTAP_TX_FLAGS          u_int16_t       bitmap
+ * IEEE80211_RADIOTAP_TX_FLAGS          uint16_t       bitmap
  *
- *	Properties of transmitted frames. See flags defined below.
+ *     Properties of transmitted frames. See flags defined below.
  *
- * IEEE80211_RADIOTAP_RTS_RETRIES       u_int8_t        data
+ * IEEE80211_RADIOTAP_RTS_RETRIES       u8           data
  *
- *	Number of rts retries a transmitted frame used.
- * 
- * IEEE80211_RADIOTAP_DATA_RETRIES      u_int8_t        data
+ *     Number of rts retries a transmitted frame used.
  *
- *	Number of unicast retries a transmitted frame used.
- * 
+ * IEEE80211_RADIOTAP_DATA_RETRIES      u8           data
+ *
+ *     Number of unicast retries a transmitted frame used.
+ *
+ * IEEE80211_RADIOTAP_MCS	u8, u8, u8		unitless
+ *
+ *     Contains a bitmap of known fields/flags, the flags, and
+ *     the MCS index.
+ *
+ * IEEE80211_RADIOTAP_AMPDU_STATUS	u32, u16, u8, u8	unitlesss
+ *
+ *	Contains the AMPDU information for the subframe.
  */
 enum ieee80211_radiotap_type {
 	IEEE80211_RADIOTAP_TSFT = 0,
@@ -195,24 +203,25 @@ enum ieee80211_radiotap_type {
 	IEEE80211_RADIOTAP_TX_FLAGS = 15,
 	IEEE80211_RADIOTAP_RTS_RETRIES = 16,
 	IEEE80211_RADIOTAP_DATA_RETRIES = 17,
-	IEEE80211_RADIOTAP_XCHANNEL = 18,
+
 	IEEE80211_RADIOTAP_MCS = 19,
-	IEEE80211_RADIOTAP_A_MPDU_STATUS = 20,
-	IEEE80211_RADIOTAP_VHT = 21,
+	IEEE80211_RADIOTAP_AMPDU_STATUS = 20,
+
+	/* valid in every it_present bitmap, even vendor namespaces */
+	IEEE80211_RADIOTAP_RADIOTAP_NAMESPACE = 29,
+	IEEE80211_RADIOTAP_VENDOR_NAMESPACE = 30,
 	IEEE80211_RADIOTAP_EXT = 31
 };
 
-#if !defined(__KERNEL__) && !defined(_KERNEL)
 /* Channel flags. */
-#define IEEE80211_CHAN_TURBO    0x0010  /* Turbo channel */
-#define IEEE80211_CHAN_CCK      0x0020  /* CCK channel */
-#define IEEE80211_CHAN_OFDM     0x0040  /* OFDM channel */
-#define IEEE80211_CHAN_2GHZ     0x0080  /* 2 GHz spectrum channel. */
-#define IEEE80211_CHAN_5GHZ     0x0100  /* 5 GHz spectrum channel */
-#define IEEE80211_CHAN_PASSIVE  0x0200  /* Only passive scan allowed */
+#define	IEEE80211_CHAN_TURBO	0x0010	/* Turbo channel */
+#define	IEEE80211_CHAN_CCK	0x0020	/* CCK channel */
+#define	IEEE80211_CHAN_OFDM	0x0040	/* OFDM channel */
+#define	IEEE80211_CHAN_2GHZ	0x0080	/* 2 GHz spectrum channel. */
+#define	IEEE80211_CHAN_5GHZ	0x0100	/* 5 GHz spectrum channel */
+#define	IEEE80211_CHAN_PASSIVE	0x0200	/* Only passive scan allowed */
 #define	IEEE80211_CHAN_DYN	0x0400	/* Dynamic CCK-OFDM channel */
 #define	IEEE80211_CHAN_GFSK	0x0800	/* GFSK channel (FHSS PHY) */
-#endif /* !defined(__KERNEL__) && !defined(_KERNEL) */
 
 /* For IEEE80211_RADIOTAP_FLAGS */
 #define	IEEE80211_RADIOTAP_F_CFP	0x01	/* sent/received
@@ -233,17 +242,50 @@ enum ieee80211_radiotap_type {
 						 * 802.11 header and payload
 						 * (to 32-bit boundary)
 						 */
+#define IEEE80211_RADIOTAP_F_BADFCS	0x40	/* frame failed FCS check */
+
 /* For IEEE80211_RADIOTAP_RX_FLAGS */
-#define	IEEE80211_RADIOTAP_F_RX_BADFCS	0x0001	/* frame failed crc check */
+#define IEEE80211_RADIOTAP_F_RX_BADPLCP	0x0002 /* bad PLCP */
 
 /* For IEEE80211_RADIOTAP_TX_FLAGS */
-#define	IEEE80211_RADIOTAP_F_TX_FAIL	0x0001	/* failed due to excessive 
+#define IEEE80211_RADIOTAP_F_TX_FAIL	0x0001	/* failed due to excessive
 						 * retries */
-#define	IEEE80211_RADIOTAP_F_TX_CTS	0x0002	/* used cts 'protection' */
-#define	IEEE80211_RADIOTAP_F_TX_RTS	0x0004	/* used rts/cts handshake */
+#define IEEE80211_RADIOTAP_F_TX_CTS	0x0002	/* used cts 'protection' */
+#define IEEE80211_RADIOTAP_F_TX_RTS	0x0004	/* used rts/cts handshake */
+#define IEEE80211_RADIOTAP_F_TX_NOACK   0x0008  /* receiver will not ack */
 
-#define IEEE80211_RADIOTAP_F_TX_NOACK   0x0008  /* Receiver will not ack */
+/* For IEEE80211_RADIOTAP_AMPDU_STATUS */
+#define IEEE80211_RADIOTAP_AMPDU_REPORT_ZEROLEN		0x0001
+#define IEEE80211_RADIOTAP_AMPDU_IS_ZEROLEN		0x0002
+#define IEEE80211_RADIOTAP_AMPDU_LAST_KNOWN		0x0004
+#define IEEE80211_RADIOTAP_AMPDU_IS_LAST		0x0008
+#define IEEE80211_RADIOTAP_AMPDU_DELIM_CRC_ERR		0x0010
+#define IEEE80211_RADIOTAP_AMPDU_DELIM_CRC_KNOWN	0x0020
+
+/* For IEEE80211_RADIOTAP_MCS */
+#define IEEE80211_RADIOTAP_MCS_HAVE_BW		0x01
+#define IEEE80211_RADIOTAP_MCS_HAVE_MCS		0x02
+#define IEEE80211_RADIOTAP_MCS_HAVE_GI		0x04
+#define IEEE80211_RADIOTAP_MCS_HAVE_FMT		0x08
+#define IEEE80211_RADIOTAP_MCS_HAVE_FEC		0x10
+#define IEEE80211_RADIOTAP_MCS_HAVE_STBC	0x20
+#define IEEE80211_RADIOTAP_MCS_HAVE_NESS	0x40
+#define IEEE80211_RADIOTAP_MCS_NESS_BIT1	0x80
 
 
+#define IEEE80211_RADIOTAP_MCS_BW_MASK		0x03
+#define		IEEE80211_RADIOTAP_MCS_BW_20	0
+#define		IEEE80211_RADIOTAP_MCS_BW_40	1
+#define		IEEE80211_RADIOTAP_MCS_BW_20L	2
+#define		IEEE80211_RADIOTAP_MCS_BW_20U	3
+#define IEEE80211_RADIOTAP_MCS_SGI		0x04
+#define IEEE80211_RADIOTAP_MCS_FMT_GF		0x08
+#define IEEE80211_RADIOTAP_MCS_FEC_LDPC		0x10
+#define IEEE80211_RADIOTAP_MCS_STBC_MASK	0x60
+#define IEEE80211_RADIOTAP_MCS_STBC_SHIFT	5
+#define		IEEE80211_RADIOTAP_MCS_STBC_1	1
+#define		IEEE80211_RADIOTAP_MCS_STBC_2	2
+#define		IEEE80211_RADIOTAP_MCS_STBC_3	3
+#define IEEE80211_RADIOTAP_MCS_NESS_BIT0	0x80
 
-#endif /* _NET_IF_IEEE80211RADIOTAP_H_ */
+#endif				/* IEEE80211_RADIOTAP_H */

--- a/userlevel/Makefile.in
+++ b/userlevel/Makefile.in
@@ -70,7 +70,7 @@ GENERIC_OBJS = string.o straccum.o nameinfo.o \
 	element.o \
 	confparse.o args.o variableenv.o lexer.o elemfilter.o routervisitor.o \
 	routerthread.o router.o master.o timerset.o selectset.o handlercall.o notifier.o \
-	integers.o md5.o radiotap.o crc32.o in_cksum.o iptable.o \
+	integers.o md5.o crc32.o in_cksum.o iptable.o \
 	archive.o userutils.o driver.o \
 	$(EXTRA_DRIVER_OBJS)
 

--- a/userlevel/Makefile.in
+++ b/userlevel/Makefile.in
@@ -70,7 +70,7 @@ GENERIC_OBJS = string.o straccum.o nameinfo.o \
 	element.o \
 	confparse.o args.o variableenv.o lexer.o elemfilter.o routervisitor.o \
 	routerthread.o router.o master.o timerset.o selectset.o handlercall.o notifier.o \
-	integers.o md5.o crc32.o in_cksum.o iptable.o \
+	integers.o md5.o radiotap.o crc32.o in_cksum.o iptable.o \
 	archive.o userutils.o driver.o \
 	$(EXTRA_DRIVER_OBJS)
 


### PR DESCRIPTION
This patch add support for 11n frame injection across the entire click router.

- Import the reference radiotap parsing code
- Add a new SettXRateHT element that can set HT rate
- Add support for retry chains 
