### PR TITLE
Update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
     - dpdk-16.07
     - dpdk-18.05
     - dpdk-19.02
-    - tcpdump-4.7.4
+    - tcpdump-4.9.3
     - netmap-11.1
 
 language: c++
@@ -17,7 +17,6 @@ env:
   global:
     - FLAGS="--enable-ip6 --enable-json --disable-linuxmodule"
     - CXXFLAGS="-std=gnu++11"
-    - GCC_VERSION="4.8"
   matrix:
     - FRAMEWORK=vanilla
     - FRAMEWORK=umultithread
@@ -58,25 +57,19 @@ script:
   - make check
 
 install:
-  - export PATH=$PATH:`pwd`/tcpdump-4.7.4/sbin/ && if [ ! -e "tcpdump-4.7.4/sbin/tcpdump" ] ; then wget http://www.tcpdump.org/release/tcpdump-4.7.4.tar.gz && tar -zxf tcpdump-4.7.4.tar.gz && cd tcpdump-4.7.4 && ./configure --prefix=`pwd` && make && make install && cd .. ; fi
+  - export PATH=$PATH:`pwd`/tcpdump-4.9.3/sbin/ && if [ ! -e "tcpdump-4.9.3/sbin/tcpdump" ] ; then wget http://www.tcpdump.org/release/tcpdump-4.9.3.tar.gz && tar -zxf tcpdump-4.9.3.tar.gz && cd tcpdump-4.9.3 && ./configure --prefix=`pwd` && make && make install && cd .. ; fi
   - if [ $FRAMEWORK = "netmap" -a ! -e "netmap-11.1/sys/net/netmap.h" ] ; then wget https://github.com/luigirizzo/netmap/archive/v11.1.tar.gz && tar -xvf v11.1.tar.gz ; fi
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
 
 addons:
   apt:
-    sources:
-        - ubuntu-toolchain-r-test
     packages:
         - libpcap-dev
         - time
         - linux-headers-generic
         - libnuma-dev
-        - gcc-4.8
-        - libstdc++-4.8-dev
-        - g++-4.8
     config:
         retries: true
 
 sudo: false
 
-dist: trusty
+dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,16 +33,17 @@ script:
   - if [ $FRAMEWORK = "dpdk" ] ; then
       FRAMEWORK_FLAGS="--enable-user-multithread --enable-dpdk";
       export RTE_SDK=`pwd`/dpdk-$VERSION;
-      export RTE_TARGET=x86_64-native-linuxapp-gcc;
+      export RTE_TARGET=x86_64-default-linuxapp-gcc;
       if [ ! -e "$RTE_SDK/$RTE_TARGET/include/rte_version.h" -o ! -e "$RTE_SDK/$RTE_TARGET/build/lib/librte_eal/linuxapp/eal/librte_eal.a" ]; then
             wget http://fast.dpdk.org/rel/dpdk-$VERSION.tar.gz &&
             tar -zxf dpdk-$VERSION.tar.gz &&
             cd dpdk-$VERSION &&
-            sed -i "s/CONFIG_RTE_ENABLE_AVX=.*/CONFIG_RTE_ENABLE_AVX=n/g" config/common_base &&
-            sed -i "s/CONFIG_RTE_KNI_KMOD=.*/CONFIG_RTE_KNI_KMOD=n/g" config/common_linuxapp &&
-            sed -i "s/CONFIG_RTE_LIBRTE_KNI=.*/CONFIG_RTE_LIBRTE_KNI=n/g" config/common_linuxapp &&
-            sed -i "s/CONFIG_RTE_EAL_IGB_UIO=.*/CONFIG_RTE_EAL_IGB_UIO=n/g" config/common_linuxapp &&
+            sed -i "s/CONFIG_RTE_KNI_KMOD=.*/CONFIG_RTE_KNI_KMOD=n/g" config/common_linux* &&
+            sed -i "s/CONFIG_RTE_LIBRTE_KNI=.*/CONFIG_RTE_LIBRTE_KNI=n/g" config/common_linux* &&
+            sed -i "s/CONFIG_RTE_EAL_IGB_UIO=.*/CONFIG_RTE_EAL_IGB_UIO=n/g" config/common_linux* &&
             sed -i "s/CONFIG_RTE_LIBRTE_VIRTIO_PMD=.*/CONFIG_RTE_LIBRTE_VIRTIO_PMD=n/g" config/common_base ;
+            cp config/defconfig_x86_64-native-linuxapp-gcc config/defconfig_x86_64-default-linuxapp-gcc ;
+            sed -i "s/CONFIG_RTE_MACHINE=.*/CONFIG_RTE_MACHINE=default/g" config/defconfig_x86_64-default-linux*-gcc ;
             make config T=$RTE_TARGET &&
             make install T=$RTE_TARGET &&
             cd ..;

--- a/userlevel/dpdk.mk
+++ b/userlevel/dpdk.mk
@@ -38,7 +38,7 @@ _LDLIBS-$(CONFIG_RTE_LIBRTE_KNI)            += -lrte_kni
 _LDLIBS-$(CONFIG_RTE_LIBRTE_IVSHMEM)        += -lrte_ivshmem
 endif
 
-ifeq ($(CONFIG_RTE_LIBRTE_PMD_OCTEONTX_SSOVF)$(CONFIG_RTE_LIBRTE_OCTEONTX_MEMPOOL)$(shell [ -n "$(RTE_VER_YEAR)" ] && ( ( [ "$(RTE_VER_YEAR)" -ge 18 ] && [ "$(RTE_VER_MONTH)" -ge 08 ] ) || [ $(RTE_VER_YEAR) -ge 19 ] ) && echo true),yytrue)
+ifeq ($(CONFIG_RTE_LIBRTE_PMD_OCTEONTX_SSOVF)$(CONFIG_RTE_LIBRTE_OCTEONTX_MEMPOOL)$(shell [ -n "$(RTE_VER_YEAR)" ] && ( ( [ "$(RTE_VER_YEAR)" -ge 18 ] && [ "$(RTE_VER_MONTH)" -ge 05 ] ) || [ $(RTE_VER_YEAR) -ge 19 ] ) && echo true),yytrue)
 	_LDLIBS-y += -lrte_common_octeontx
 endif
 


### PR DESCRIPTION
There is a bug in travis because the APT source is not authenticated, but we have no way to pass some more options to apt.

Anyway now we can switch to an Ubuntu that has GCC >=4.8 by default
(required for C++ 11), that's cleaner.

Also upgrade tcpdump to 4.9.3 as 4.7.3 does not compile with recent GCC, fix DPDK CPU architecture because newer machines may have newer CPUs and therefore DPDK could compile on a new CPU architecture, but run on an old, and a little DPDK compilation fix.