### PR TITLE
FromDevice/RawSocket: fix linux headers for 5.2

### DIFF
--- a/elements/userlevel/fromdevice.cc
+++ b/elements/userlevel/fromdevice.cc
@@ -51,6 +51,7 @@
 # include <features.h>
 # include <linux/if_packet.h>
 # include <net/ethernet.h>
+# include <linux/sockios.h>
 #endif
 
 CLICK_DECLS

--- a/elements/userlevel/rawsocket.cc
+++ b/elements/userlevel/rawsocket.cc
@@ -35,6 +35,10 @@
 #include <arpa/inet.h>
 #include <fcntl.h>
 
+#if RAWSOCKET_ALLOW_LINUX
+# include <linux/sockios.h>
+#endif
+
 #ifndef __sun
 #include <sys/ioctl.h>
 #else

--- a/elements/userlevel/rawsocket.hh
+++ b/elements/userlevel/rawsocket.hh
@@ -5,6 +5,11 @@
 #include <click/task.hh>
 #include <click/timer.hh>
 #include <click/notifier.hh>
+
+#ifdef __linux__
+# define RAWSOCKET_ALLOW_LINUX 1
+#endif
+
 CLICK_DECLS
 
 /*


### PR DESCRIPTION
In kernel 5.2, the linux kernel team moved the definition of various
constants around between headers, which breaks building click usermode
on linux kernels >= 5.2.

Specifically, the constant SIOCGSTAMP was moved to <linux/sockios.h>
when they updated the ioctl to work with 64-bit struct timeval.

This commit adds the <linux/sockios.h> header in the places where this
constant is used (FromDevce and RawSocket), gated to only apply to linux
builds.

I have tested this to compile on kernel 4.19 and 5.3.