### PR TITLE
patches rss_hf calculation for dpdk devices.

### DIFF
--- a/lib/dpdkdevice.cc
+++ b/lib/dpdkdevice.cc
@@ -122,6 +122,7 @@ int DPDKDevice::initialize_device(ErrorHandler *errh)
     dev_conf.rxmode.mq_mode = ETH_MQ_RX_RSS;
     dev_conf.rx_adv_conf.rss_conf.rss_key = NULL;
     dev_conf.rx_adv_conf.rss_conf.rss_hf = ETH_RSS_IP | ETH_RSS_UDP | ETH_RSS_TCP;
+    dev_conf.rx_adv_conf.rss_conf.rss_hf &= dev_info.flow_type_rss_offloads;
 
     //We must open at least one queue per direction
     if (info.rx_queues.size() == 0) {


### PR DESCRIPTION
Patch for the rss_hf calculation in lib/dpdkdevice.cc leading to Issue #444 . Calculation is now equal to the one used in fastclicks lib/dpdkdevice.cc .