### PR TITLE
Make sure that UNIX sockets are removed before binding to them

### DIFF
--- a/elements/userlevel/chattersocket.cc
+++ b/elements/userlevel/chattersocket.cc
@@ -217,6 +217,7 @@ ChatterSocket::initialize_socket(ErrorHandler *errh)
     struct sockaddr_un sa;
     sa.sun_family = AF_UNIX;
     memcpy(sa.sun_path, _unix_pathname.c_str(), _unix_pathname.length() + 1);
+    unlink(_unix_pathname.c_str());
     if (bind(_socket_fd, (struct sockaddr *)&sa, sizeof(sa)) < 0)
       return initialize_socket_error(errh, "bind");
   }

--- a/elements/userlevel/controlsocket.cc
+++ b/elements/userlevel/controlsocket.cc
@@ -215,6 +215,7 @@ ControlSocket::initialize_socket(ErrorHandler *errh)
     struct sockaddr_un sa;
     sa.sun_family = AF_UNIX;
     memcpy(sa.sun_path, _unix_pathname.c_str(), _unix_pathname.length() + 1);
+    unlink(_unix_pathname.c_str());
     if (bind(_socket_fd, (struct sockaddr *)&sa, sizeof(sa)) < 0)
       return initialize_socket_error(errh, "bind");
 

--- a/elements/userlevel/socket.cc
+++ b/elements/userlevel/socket.cc
@@ -208,6 +208,8 @@ Socket::initialize(ErrorHandler *errh)
     }
     if (ret < 0)
 #endif
+    if (_local_pathname != "")
+      unlink(_local_pathname.c_str());
     if (bind(_fd, (struct sockaddr *)&_local, _local_len) < 0)
       return initialize_socket_error(errh, "bind");
   }


### PR DESCRIPTION
We run linux userspace click under the runit process supervisor. Sometimes click coredumps for one reason or another, and when restarting click we encounter errors about "address already in use", sometimes from the click control socket file, and sometimes from other unix socket files.

Socket and ControlSocket cleanup code will attempt to remove the
unix socket files they create. However, if click were to crash or
otherwise exit without calling cleanup, click will require an operator
to intervene and delete any unix socket resources not removed.

This change places an unlink() call before calls to bind() where
a unix socket is used. No error or logging is handled since it
is a best effort attempt to cleanup the unix socket.

I haven't done much evaluation on what the side effects might be, but I believe there aren't any? Feedback is appreciated, and I hope this helps.