### PR TITLE
Check if linux_true is defined

### DIFF
--- a/include/click/cxxprotect.h
+++ b/include/click/cxxprotect.h
@@ -9,7 +9,9 @@
 # define public		linux_public
 # define namespace	linux_namespace
 # define false		linux_false
+# ifdef linux_true
 # define true		linux_true
+# endif
 #endif
 
 #ifndef CLICK_CXX_PROTECT

--- a/include/clicknet/ip.h
+++ b/include/clicknet/ip.h
@@ -9,9 +9,7 @@ CLICK_CXX_PROTECT
 # include <linux/in.h>
 #else
 # include <sys/types.h>
-#undef true
 # include <netinet/in.h>
-#define true linux_true
 #endif
 
 /*


### PR DESCRIPTION
* Fix the compilation error in #493.
* Tested with config options `./configure --prefix=/usr --sbindir=/usr/bin --enable-all-elements` on Linux 5.18.7.
* Should be backward compatible, but haven't yet tested it in older Ubuntu machines.