### PR TITLE
[#510]Fix incorrect MAC header size calculation in VLANEncap element.

### DIFF
--- a/elements/ethernet/vlanencap.cc
+++ b/elements/ethernet/vlanencap.cc
@@ -73,7 +73,7 @@ VLANEncap::simple_action(Packet *p)
 	click_ether_vlan *vlan = reinterpret_cast<click_ether_vlan *>(q->data());
 	vlan->ether_vlan_proto = _ethertype;
 	vlan->ether_vlan_tci = tci;
-	q->set_mac_header(q->data(), sizeof(vlan));
+	q->set_mac_header(q->data(), sizeof(click_ether_vlan));
 	return q;
     } else
 	return 0;


### PR DESCRIPTION
Replace sizeof(vlan) with sizeof(click_ether_vlan) to use proper struct size instead of pointer size. This ensures correct network header offset anno in the packet for VLAN encapsulated packets.